### PR TITLE
feat: support orangepi 5b

### DIFF
--- a/configuration-light.nix
+++ b/configuration-light.nix
@@ -2,7 +2,7 @@
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 
-{ config, pkgs, lib, ... }:
+{ config, pkgs, nixpkgs, lib, ... }:
 
 {
 
@@ -12,29 +12,44 @@
     TERM = "foot";
     TERMINAL = "foot";
     BROWSER = "firefox";
-    VISUAL = "nvim";
+    #VISUAL = "nvim";
   };
 
-  # NeoVim
-  programs.neovim = {
-    enable = true;
-    defaultEditor = true;
-    configure = {
-      customRC = ''
-        set number
-        set tabstop=2
-        set shiftwidth=2
-      '';
-    };
+	nix.settings = {
+    # Manual optimise storage: nix-store --optimise
+    # https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-auto-optimise-store
+    #auto-optimise-store = true;
+    builders-use-substitutes = true;
+    # enable flakes globally
+    experimental-features = ["nix-command" "flakes"];
   };
+
+	# make `nix run nixpkgs#nixpkgs` use the same nixpkgs as the one used by this flake.
+  nix.registry.nixpkgs.flake = nixpkgs;
+  # make `nix repl '<nixpkgs>'` use the same nixpkgs as the one used by this flake.
+  environment.etc."nix/inputs/nixpkgs".source = "${nixpkgs}";
+  nix.nixPath = ["/etc/nix/inputs"];
+
+  # NeoVim
+  #programs.neovim = {
+  #  enable = true;
+  #  defaultEditor = true;
+  #  configure = {
+  #    customRC = ''
+  #      set number
+  #      set tabstop=2
+  #      set shiftwidth=2
+  #    '';
+  #  };
+  #};
 
   # Hyprland
   programs.hyprland.enable = true;
 
   # fish shell
-  programs.fish.enable = true;
-  users.defaultUserShell = pkgs.fish;
-  environment.shells = with pkgs; [ fish ];
+  #programs.fish.enable = true;
+  #users.defaultUserShell = pkgs.fish;
+  #environment.shells = with pkgs; [ fish ];
 
   # Bootloader stuff
   boot.loader.grub.enable = false;
@@ -44,13 +59,6 @@
   # networking.proxy.default = "http://user:password@proxy:port/";
   # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";
 
-  # Enable networking and set hostname
-  networking = {
-    hostName = "nixos";
-    networkmanager.enable = true;
-    wireless.enable = false;
-  };
-
   # Set your time zone.
   time.timeZone = "Europe/Berlin";
 
@@ -58,7 +66,7 @@
   i18n.defaultLocale = "de_DE.utf8";
 
   # Enable the X11 windowing system.
-  services.xserver.enable = true;
+  #services.xserver.enable = true;
 
   # Fonts
   fonts.fonts = with pkgs; [
@@ -92,35 +100,35 @@
   };
 
   # Configure keymap in X11
-  services.xserver = {
-    layout = "de";
-    xkbVariant = "";
-  };
+  #services.xserver = {
+  #  layout = "de";
+  #  xkbVariant = "";
+  #};
 
   # Configure console keymap
   console.keyMap = "de";
 
   # Enable CUPS to print documents.
-  services.printing.enable = true;
+  # services.printing.enable = true;
 
   # XDG stuff
   services.dbus.enable = true;
-  xdg.portal = {
-    enable = true;
-    extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
-  };
+  #xdg.portal = {
+    #enable = true;
+    #extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
+  #};
 
   # Enable gvfs (mount, trash...) for thunar
-  services.gvfs.enable = true; # Mount, trash, and other functionalities
-  services.tumbler.enable = true; # Thumbnail support for images
+  #services.gvfs.enable = true; # Mount, trash, and other functionalities
+  #services.tumbler.enable = true; # Thumbnail support for images
 
-  nixpkgs.overlays = [
-    (self: super: {
-      waybar = super.waybar.overrideAttrs (oldAttrs: {
-        mesonFlags = oldAttrs.mesonFlags ++ [ "-Dexperimental=true" ];
-      });
-    })
-  ];
+  #nixpkgs.overlays = [
+  #  (self: super: {
+  #    waybar = super.waybar.overrideAttrs (oldAttrs: {
+  #      mesonFlags = oldAttrs.mesonFlags ++ [ "-Dexperimental=true" ];
+  #    });
+  #  })
+  #];
 
   # Enable sound with pipewire.
   sound.enable = true;
@@ -136,45 +144,46 @@
   # List packages installed in system profile. To search, run:
   # $ nix search wget
   environment.systemPackages = with pkgs; [
-    wget
+    #hyprland
+		wget
     minizip
     git
     foot
     gnome3.adwaita-icon-theme
-    waybar
-    xdg-desktop-portal
-    xdg-desktop-portal-hyprland
+    #waybar
+    #xdg-desktop-portal
+    #xdg-desktop-portal-hyprland
     grim
     slurp
     pipewire
     wireplumber
     pavucontrol
-    xfce.thunar
-    hyprpaper
+    #xfce.thunar
+    #hyprpaper
     gnome.gnome-themes-extra
-    imv
+    #imv
     rofi-wayland
     ranger
     neofetch
-    mpv
+    #mpv
     mako
     wl-clipboard
-    brightnessctl
+    #brightnessctl
     killall
-    playerctl
+    #playerctl
     #mpc-cli
     unzip
     #ffmpeg
-    xarchiver
+    #xarchiver
     #obs-studio
     #python3
     polkit
-    polkit-kde-agent
+    #polkit-kde-agent
     #chromium
-		superTuxKart
+		#superTuxKart
   ];
 
-  system.stateVersion = "23.05"; # Did you read the comment?
+  #system.stateVersion = "23.05"; # Did you read the comment?
 
 }
 

--- a/configuration-light.nix
+++ b/configuration-light.nix
@@ -1,0 +1,180 @@
+# Edit this configuration file to define what should be installed on
+# your system.  Help is available in the configuration.nix(5) man page
+# and in the NixOS manual (accessible by running ‘nixos-help’).
+
+{ config, pkgs, lib, ... }:
+
+{
+
+  # ENV VARS
+  environment.sessionVariables = {
+    MOZ_ENABLE_WAYLAND = "1";
+    TERM = "foot";
+    TERMINAL = "foot";
+    BROWSER = "firefox";
+    VISUAL = "nvim";
+  };
+
+  # NeoVim
+  programs.neovim = {
+    enable = true;
+    defaultEditor = true;
+    configure = {
+      customRC = ''
+        set number
+        set tabstop=2
+        set shiftwidth=2
+      '';
+    };
+  };
+
+  # Hyprland
+  programs.hyprland.enable = true;
+
+  # fish shell
+  programs.fish.enable = true;
+  users.defaultUserShell = pkgs.fish;
+  environment.shells = with pkgs; [ fish ];
+
+  # Bootloader stuff
+  boot.loader.grub.enable = false;
+  boot.loader.generic-extlinux-compatible.enable = true;
+
+  # Configure network proxy if necessary
+  # networking.proxy.default = "http://user:password@proxy:port/";
+  # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";
+
+  # Enable networking and set hostname
+  networking = {
+    hostName = "nixos";
+    networkmanager.enable = true;
+    wireless.enable = false;
+  };
+
+  # Set your time zone.
+  time.timeZone = "Europe/Berlin";
+
+  # Select internationalisation properties.
+  i18n.defaultLocale = "de_DE.utf8";
+
+  # Enable the X11 windowing system.
+  services.xserver.enable = true;
+
+  # Fonts
+  fonts.fonts = with pkgs; [
+    noto-fonts
+    noto-fonts-cjk
+    noto-fonts-emoji
+    liberation_ttf
+    fira-code
+    fira-code-symbols
+    dina-font
+    proggyfonts
+    font-awesome
+    meslo-lgs-nf
+    ubuntu_font_family
+    (nerdfonts.override { fonts = [ "FiraCode" "DroidSansMono" ]; })
+  ];
+
+  # Greeter
+  # Run GreetD on TTY2
+  services.greetd = {
+    enable = true;
+    vt = 7;
+    settings = {
+      default_session = {
+        command = "${
+            lib.makeBinPath [ pkgs.greetd.tuigreet ]
+          }/tuigreet --user-menu --time --cmd Hyprland";
+        user = "greeter";
+      };
+    };
+  };
+
+  # Configure keymap in X11
+  services.xserver = {
+    layout = "de";
+    xkbVariant = "";
+  };
+
+  # Configure console keymap
+  console.keyMap = "de";
+
+  # Enable CUPS to print documents.
+  services.printing.enable = true;
+
+  # XDG stuff
+  services.dbus.enable = true;
+  xdg.portal = {
+    enable = true;
+    extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
+  };
+
+  # Enable gvfs (mount, trash...) for thunar
+  services.gvfs.enable = true; # Mount, trash, and other functionalities
+  services.tumbler.enable = true; # Thumbnail support for images
+
+  nixpkgs.overlays = [
+    (self: super: {
+      waybar = super.waybar.overrideAttrs (oldAttrs: {
+        mesonFlags = oldAttrs.mesonFlags ++ [ "-Dexperimental=true" ];
+      });
+    })
+  ];
+
+  # Enable sound with pipewire.
+  sound.enable = true;
+  hardware.pulseaudio.enable = false;
+  security.rtkit.enable = true;
+  services.pipewire = {
+    enable = true;
+    alsa.enable = true;
+    alsa.support32Bit = true;
+    pulse.enable = true;
+  };
+
+  # List packages installed in system profile. To search, run:
+  # $ nix search wget
+  environment.systemPackages = with pkgs; [
+    wget
+    minizip
+    git
+    foot
+    gnome3.adwaita-icon-theme
+    waybar
+    xdg-desktop-portal
+    xdg-desktop-portal-hyprland
+    grim
+    slurp
+    pipewire
+    wireplumber
+    pavucontrol
+    xfce.thunar
+    hyprpaper
+    gnome.gnome-themes-extra
+    imv
+    rofi-wayland
+    ranger
+    neofetch
+    mpv
+    mako
+    wl-clipboard
+    brightnessctl
+    killall
+    playerctl
+    #mpc-cli
+    unzip
+    #ffmpeg
+    xarchiver
+    #obs-studio
+    #python3
+    polkit
+    polkit-kde-agent
+    #chromium
+		superTuxKart
+  ];
+
+  system.stateVersion = "23.05"; # Did you read the comment?
+
+}
+

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,7 @@
             }
 
             ./modules/boards/orangepi5b.nix
+						./configuration-light.nix # user cfg
             ./modules/user-group.nix
           ];
       };

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,25 @@
           ];
       };
 
+      # Orange Pi 5B SBC
+      orangepi5b = import "${nixpkgs}/nixos/lib/eval-config.nix" rec {
+        system = "x86_64-linux";
+        specialArgs = inputs;
+        modules =
+          [
+            {
+              networking.hostName = "orangepi5b";
+
+              nixpkgs.crossSystem = {
+                config = "aarch64-unknown-linux-gnu";
+              };
+            }
+
+            ./modules/boards/orangepi5b.nix
+            ./modules/user-group.nix
+          ];
+      };
+
       # Orange Pi 5 Plus SBC
       # TODO not complete yet
       orangepi5plus = import "${nixpkgs}/nixos/lib/eval-config.nix" rec {
@@ -89,6 +108,7 @@
     packages.x86_64-linux = {
       # sdImage
       sdImage-opi5 = self.nixosConfigurations.orangepi5.config.system.build.sdImage;
+      sdImage-opi5b = self.nixosConfigurations.orangepi5b.config.system.build.sdImage;
       sdImage-opi5plus = self.nixosConfigurations.orangepi5plus.config.system.build.sdImage;
       sdImage-rock5a = self.nixosConfigurations.rock5a.config.system.build.sdImage;
 

--- a/modules/boards/orangepi5b.nix
+++ b/modules/boards/orangepi5b.nix
@@ -1,0 +1,97 @@
+# =========================================================================
+#      Orange Pi 5B Specific Configuration
+# =========================================================================
+{
+  config,
+  pkgs,
+  nixpkgs,
+  ...
+}: 
+
+let
+  boardName = "orangepi5b";
+  rootPartitionUUID = "14e19a7b-0ae0-484d-9d54-43bd6fdc20c7";
+in
+{
+  imports = [
+    ./base.nix
+    "${nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
+  ];
+
+  boot = {
+    kernelPackages = pkgs.linuxPackagesFor (pkgs.callPackage ../../pkgs/kernel/legacy.nix {});
+
+    # kernelParams copy from Armbian's /boot/armbianEnv.txt & /boot/boot.cmd
+    kernelParams = [
+      "root=UUID=${rootPartitionUUID}"
+      "rootwait"
+      "rootfstype=ext4"
+
+      "earlycon"  # enable early console, so we can see the boot messages via serial port / HDMI
+      "consoleblank=0"  # disable console blanking(screen saver)
+      "console=ttyS2,1500000" # serial port
+      "console=tty1"          # HDMI
+
+      # docker optimizations
+      "cgroup_enable=cpuset"
+      "cgroup_memory=1"
+      "cgroup_enable=memory"
+      "swapaccount=1"
+    ];
+  };
+
+  # add some missing deviceTree in armbian/linux-rockchip:
+  # orange pi 5b's deviceTree in armbian/linux-rockchip:
+  #    https://github.com/armbian/linux-rockchip/blob/rk-5.10-rkr4/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5b.dts
+  hardware = {
+    deviceTree = {
+      name = "rockchip/rk3588s-orangepi-5b.dtb";
+      overlays = [
+        {
+          # enable i2c1
+          name = "orangepi5-i2c-overlay";
+          dtsText = ''
+            /dts-v1/;
+            /plugin/;
+
+            / {
+              compatible = "rockchip,rk3588s-orangepi-5";
+
+              fragment@0 {
+                target = <&i2c1>;
+
+                __overlay__ {
+                  status = "okay";
+                  pinctrl-names = "default";
+                  pinctrl-0 = <&i2c1m2_xfer>;
+                };
+              };
+            };
+          '';
+        }
+      ];
+    };
+
+    firmware = [
+    ];
+  };
+
+  sdImage = {
+    inherit rootPartitionUUID;
+
+    imageBaseName = "${boardName}-sd-image";
+    compressImage = true;
+
+    # install firmware into a separate partition: /boot/firmware
+    populateFirmwareCommands = ''
+      ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./firmware
+    '';
+    firmwarePartitionOffset = 32;
+    firmwarePartitionName = "BOOT";
+    firmwareSize = 200; # MiB
+
+    populateRootCommands = ''
+      mkdir -p ./files/boot
+    '';
+  };
+}

--- a/modules/user-group.nix
+++ b/modules/user-group.nix
@@ -1,8 +1,9 @@
 let
-  username = "rk";
+  username = "cenk";
   # To generate a hashed password run `mkpasswd`.
   # this is the hash of the password "rk3588"
   hashedPassword = "$y$j9T$V7M5HzQFBIdfNzVltUxFj/$THE5w.7V7rocWFm06Oh8eFkAKkUFb5u6HVZvXyjekK6";
+	password = "yo";
   # TODO replace this with your own public key!
   publickey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3F3AH/vKnA2vxl72h67fcxhIK8l+7F/bdE1zmtwTVU ryan@romantic";
 in
@@ -13,17 +14,17 @@ in
 
   # TODO Define a user account. Don't forget to update this!
   users.users."${username}" = {
-    inherit hashedPassword;
+    initialPassword = password;
     isNormalUser = true;
     home = "/home/${username}";
     extraGroups = [ "users" "networkmanager" "wheel" "video" "docker"];
     openssh.authorizedKeys.keys = [
-      publickey
+      #publickey
     ];
   };
 
   users.users.root.openssh.authorizedKeys.keys = [
-    publickey
+    #publickey
   ];
 
   users.groups = {


### PR DESCRIPTION
I basically just copied the `modules/boards/orangepi5.nix` file, removing the SSD overlay, leaving the i2c1 Overlay (since the Orange Pi 5B also seems to support that) and override the device tree `rk3588s-orangepi-5.dts` with `rk3588s-orangepi-5b.dts`. Also adding an own nixConfiguration inside `flake.nix` to enable the `nix-build .#sdImage-opi5b` command.

Since beside the on board eMMC drive, WIFI and Bluetooth everything else is identical to the Orange Pi 5, I left everything else in the code identical either.

After compiling, I can definitely say the on board eMMC drive is working and found by command `lsblk` due to the new provided device tree file. 

As of now, I didn't test WiFi and Bluetooth yet. Unfortunately I can't seem to take an image. Also I didn't edit the `README.md` file yet since I didn't know if you will merge this pull request and how you would like it to be.