### PR TITLE
Better defaults

### DIFF
--- a/demo/configuration.nix
+++ b/demo/configuration.nix
@@ -1,4 +1,4 @@
-{config, pkgs, nixpkgs, ...}: {
+{ config, pkgs, nixpkgs, ... }: {
 
   # =========================================================================
   #      Base NixOS Configuration
@@ -16,14 +16,14 @@
     auto-optimise-store = true;
     builders-use-substitutes = true;
     # enable flakes globally
-    experimental-features = ["nix-command" "flakes"];
+    experimental-features = [ "nix-command" "flakes" ];
   };
 
   # make `nix run nixpkgs#nixpkgs` use the same nixpkgs as the one used by this flake.
   nix.registry.nixpkgs.flake = nixpkgs;
   # make `nix repl '<nixpkgs>'` use the same nixpkgs as the one used by this flake.
   environment.etc."nix/inputs/nixpkgs".source = "${nixpkgs}";
-  nix.nixPath = ["/etc/nix/inputs"];
+  nix.nixPath = [ "/etc/nix/inputs" ];
 
   # List packages installed in system profile. To search, run:
   # $ nix search wget
@@ -33,12 +33,12 @@
     neovim
 
     # networking
-    mtr      # A network diagnostic tool
-    iperf3   # A tool for measuring TCP and UDP bandwidth performance
-    nmap     # A utility for network discovery and security auditing
-    ldns     # replacement of dig, it provide the command `drill`
-    socat    # replacement of openbsd-netcat
-    tcpdump  # A powerful command-line packet analyzer
+    mtr # A network diagnostic tool
+    iperf3 # A tool for measuring TCP and UDP bandwidth performance
+    nmap # A utility for network discovery and security auditing
+    ldns # replacement of dig, it provide the command `drill`
+    socat # replacement of openbsd-netcat
+    tcpdump # A powerful command-line packet analyzer
 
     # archives
     zip
@@ -72,7 +72,7 @@
     enable = true;
     settings = {
       X11Forwarding = true;
-      PermitRootLogin = "prohibit-password";  # disable root login with password
+      PermitRootLogin = "prohibit-password"; # disable root login with password
       PasswordAuthentication = false; # disable password login
     };
     openFirewall = true;

--- a/demo/configuration.nix
+++ b/demo/configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, nixpkgs, ... }: {
+{ pkgs, nixpkgs, ... }: {
 
   # =========================================================================
   #      Base NixOS Configuration

--- a/demo/flake.lock
+++ b/demo/flake.lock
@@ -1,5 +1,45 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixos-rk3588",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "mesa-panfork": {
       "flake": false,
       "locked": {
@@ -19,21 +59,20 @@
     },
     "nixos-rk3588": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "mesa-panfork": "mesa-panfork",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1692208784,
-        "narHash": "sha256-3AetKtb1oz1vJ7ZTy78v642Bwz/NxPahNCVN9eqO8rU=",
-        "owner": "ryan4yin",
-        "repo": "nixos-rk3588",
-        "rev": "db96e4436b369a3b7e52e285347bed2bec6337b6",
-        "type": "github"
+        "lastModified": 0,
+        "narHash": "sha256-73eVzrcVV0RwDGF5/fmppmwxo7eyRx8yJkE9920c/nQ=",
+        "path": "..",
+        "type": "path"
       },
       "original": {
-        "owner": "ryan4yin",
-        "repo": "nixos-rk3588",
-        "type": "github"
+        "path": "..",
+        "type": "path"
       }
     },
     "nixpkgs": {
@@ -52,26 +91,57 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "nixos-rk3588"
+        ],
+        "flake-utils": [
+          "nixos-rk3588",
+          "flake-utils"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixos-rk3588",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "nixos-rk3588",
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1692192038,
-        "narHash": "sha256-fXUZ7GF2VPoLGP0DmTbdUxCRRFVZWn09XvopOqDOAFg=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "b0c9d793fcab2f749ab3d543ba42facf90bb1bd9",
+        "lastModified": 1700064067,
+        "narHash": "sha256-1ZWNDzhu8UlVCK7+DUN9dVQfiHX1bv6OQP9VxstY/gs=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "e558068cba67b23b4fbc5537173dbb43748a17e8",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-23.05-small",
-        "repo": "nixpkgs",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "nixos-rk3588": "nixos-rk3588",
-        "nixpkgs": "nixpkgs_2"
+        "nixos-rk3588": "nixos-rk3588"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/demo/flake.nix
+++ b/demo/flake.nix
@@ -1,11 +1,9 @@
 {
   description = "NixOS configuration for rk3588 remote deployment";
 
-  inputs = {
-    # Change to:
-    # nixos-rk3588.url = "github:ryan4yin/nixos-rk3588";
-    nixos-rk3588.url = "path:..";
-  };
+  # Change to:
+  # nixos-rk3588.url = "github:ryan4yin/nixos-rk3588";
+  inputs.nixos-rk3588.url = "path:..";
 
   outputs =
     { nixos-rk3588
@@ -20,7 +18,12 @@
         meta = {
           # using the same nixpkgs as nixos-rk3588 to utilize the cross-compilation cache.
           nixpkgs = import nixos-rk3588.inputs.nixpkgs { inherit system; };
-          specialArgs = nixos-rk3588.inputs;
+          specialArgs = {
+            inherit (nixos-rk3588.inputs) nixpkgs;
+
+            # Provide rk3588 inputs as special argument
+            rk3588 = nixos-rk3588.inputs;
+          };
         };
 
         opi5 = {
@@ -29,15 +32,11 @@
           # Allow local deployment with `colmena apply-local`
           # deployment.allowLocalDeployment = true;
 
-          imports = [
-            {
-              # Use the crossSystem configuration for cross-compilation
-              # Remove this module if you want to compile natively on aarch64-linux!
-              nixpkgs.crossSystem = {
-                config = "aarch64-unknown-linux-gnu";
-              };
-            }
+          # Use the crossSystem configuration for cross-compilation
+          # Remove this line if you want to compile natively on aarch64-linux!
+          nixpkgs.crossSystem.config = "aarch64-unknown-linux-gnu";
 
+          imports = [
             # import the rk3588 module, which contains the configuration for bootloader/kernel/firmware
             nixos-rk3588.nixosModules.orangepi5
 

--- a/demo/flake.nix
+++ b/demo/flake.nix
@@ -8,8 +8,7 @@
   };
 
   outputs =
-    { self
-    , nixos-rk3588
+    { nixos-rk3588
     , ...
     }:
     let
@@ -24,33 +23,29 @@
           specialArgs = nixos-rk3588.inputs;
         };
 
-        opi5 =
-          { name
-          , nodes
-          , ...
-          }: {
-            deployment.targetHost = "192.168.5.42";
-            deployment.targetUser = "root";
-            # Allow local deployment with `colmena apply-local`
-            # deployment.allowLocalDeployment = true;
+        opi5 = {
+          deployment.targetHost = "192.168.5.42";
+          deployment.targetUser = "root";
+          # Allow local deployment with `colmena apply-local`
+          # deployment.allowLocalDeployment = true;
 
-            imports = [
-              {
-                # Use the crossSystem configuration for cross-compilation
-                # Remove this module if you want to compile natively on aarch64-linux!
-                nixpkgs.crossSystem = {
-                  config = "aarch64-unknown-linux-gnu";
-                };
-              }
+          imports = [
+            {
+              # Use the crossSystem configuration for cross-compilation
+              # Remove this module if you want to compile natively on aarch64-linux!
+              nixpkgs.crossSystem = {
+                config = "aarch64-unknown-linux-gnu";
+              };
+            }
 
-              # import the rk3588 module, which contains the configuration for bootloader/kernel/firmware
-              nixos-rk3588.nixosModules.orangepi5
+            # import the rk3588 module, which contains the configuration for bootloader/kernel/firmware
+            nixos-rk3588.nixosModules.orangepi5
 
-              # your custom configuration
-              ./configuration.nix
-              ./user-group.nix
-            ];
-          };
+            # your custom configuration
+            ./configuration.nix
+            ./user-group.nix
+          ];
+        };
       };
     };
 }

--- a/demo/flake.nix
+++ b/demo/flake.nix
@@ -2,13 +2,13 @@
   description = "NixOS configuration for rk3588 remote deployment";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05-small";
-    nixos-rk3588.url = "github:ryan4yin/nixos-rk3588";
+    # Change to:
+    # nixos-rk3588.url = "github:ryan4yin/nixos-rk3588";
+    nixos-rk3588.url = "path:..";
   };
 
   outputs = {
     self,
-    nixpkgs,
     nixos-rk3588,
     ...
   }: let
@@ -42,7 +42,7 @@
           }
 
           # import the rk3588 module, which contains the configuration for bootloader/kernel/firmware
-          (nixos-rk3588 + "/modules/boards/orangepi5.nix")
+          nixos-rk3588.nixosModules.orangepi5
 
           # your custom configuration
           ./configuration.nix

--- a/demo/flake.nix
+++ b/demo/flake.nix
@@ -7,48 +7,50 @@
     nixos-rk3588.url = "path:..";
   };
 
-  outputs = {
-    self,
-    nixos-rk3588,
-    ...
-  }: let
-    system = "x86_64-linux"; # for cross-compilation on x86_64-linux
-    # system = "aarch64-linux";  # for native compilation on aarch64-linux
-  in {
-    colmena = {
-      meta = {
-        # using the same nixpkgs as nixos-rk3588 to utilize the cross-compilation cache.
-        nixpkgs = import nixos-rk3588.inputs.nixpkgs {inherit system;};
-        specialArgs = nixos-rk3588.inputs;
-      };
+  outputs =
+    { self
+    , nixos-rk3588
+    , ...
+    }:
+    let
+      system = "x86_64-linux"; # for cross-compilation on x86_64-linux
+      # system = "aarch64-linux";  # for native compilation on aarch64-linux
+    in
+    {
+      colmena = {
+        meta = {
+          # using the same nixpkgs as nixos-rk3588 to utilize the cross-compilation cache.
+          nixpkgs = import nixos-rk3588.inputs.nixpkgs { inherit system; };
+          specialArgs = nixos-rk3588.inputs;
+        };
 
-      opi5 = {
-        name,
-        nodes,
-        ...
-      }: {
-        deployment.targetHost = "192.168.5.42";
-        deployment.targetUser = "root";
-        # Allow local deployment with `colmena apply-local`
-        # deployment.allowLocalDeployment = true;
+        opi5 =
+          { name
+          , nodes
+          , ...
+          }: {
+            deployment.targetHost = "192.168.5.42";
+            deployment.targetUser = "root";
+            # Allow local deployment with `colmena apply-local`
+            # deployment.allowLocalDeployment = true;
 
-        imports = [
-          {
-            # Use the crossSystem configuration for cross-compilation
-            # Remove this module if you want to compile natively on aarch64-linux!
-            nixpkgs.crossSystem = {
-              config = "aarch64-unknown-linux-gnu";
-            };
-          }
+            imports = [
+              {
+                # Use the crossSystem configuration for cross-compilation
+                # Remove this module if you want to compile natively on aarch64-linux!
+                nixpkgs.crossSystem = {
+                  config = "aarch64-unknown-linux-gnu";
+                };
+              }
 
-          # import the rk3588 module, which contains the configuration for bootloader/kernel/firmware
-          nixos-rk3588.nixosModules.orangepi5
+              # import the rk3588 module, which contains the configuration for bootloader/kernel/firmware
+              nixos-rk3588.nixosModules.orangepi5
 
-          # your custom configuration
-          ./configuration.nix
-          ./user-group.nix
-        ];
+              # your custom configuration
+              ./configuration.nix
+              ./user-group.nix
+            ];
+          };
       };
     };
-  };
 }

--- a/demo/user-group.nix
+++ b/demo/user-group.nix
@@ -19,7 +19,7 @@ in
     inherit hashedPassword;
     isNormalUser = true;
     home = "/home/${username}";
-    extraGroups = [ "users" "networkmanager" "wheel" "video" "docker"];
+    extraGroups = [ "users" "networkmanager" "wheel" "video" "docker" ];
     openssh.authorizedKeys.keys = [
       publickey
     ];
@@ -30,7 +30,7 @@ in
   ];
 
   users.groups = {
-    "${username}" = {};
-    docker = {};
+    "${username}" = { };
+    docker = { };
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "mesa-panfork": {
       "flake": false,
       "locked": {
@@ -35,8 +53,24 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "mesa-panfork": "mesa-panfork",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,27 @@
         "type": "github"
       }
     },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "mesa-panfork": {
       "flake": false,
       "locked": {
@@ -51,11 +72,40 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": [],
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1700064067,
+        "narHash": "sha256-1ZWNDzhu8UlVCK7+DUN9dVQfiHX1bv6OQP9VxstY/gs=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "e558068cba67b23b4fbc5537173dbb43748a17e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "mesa-panfork": "mesa-panfork",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,103 +11,107 @@
     };
   };
 
-  outputs = inputs@{self, nixpkgs, ...}: let
-    pkgsKernel = import nixpkgs {
-      system = "x86_64-linux";
-      crossSystem = {
-        config = "aarch64-unknown-linux-gnu";
-      };
-
-      overlays = [
-        (self: super: {
-          linuxPackages_rockchip = super.linuxPackagesFor (super.callPackage ./pkgs/kernel/legacy.nix {});
-        })
-      ];
-    };
-  in {
-    nixosModules = {
-      # Orange Pi 5 SBC
-      orangepi5 = import ./modules/boards/orangepi5.nix;
-      # Orange Pi 5 Plus SBC
-      # TODO not complete yet
-      orangepi5plus = import ./modules/boards/orangepi5plus.nix;
-      # Rock 5 Model A SBC
-      # TODO not complete yet
-      rock5a = import ./modules/boards/rock5a.nix;
-    };
-
-    nixosConfigurations = builtins.mapAttrs (name: module:
-      import "${nixpkgs}/nixos/lib/eval-config.nix" {
+  outputs = inputs@{ self, nixpkgs, ... }:
+    let
+      pkgsKernel = import nixpkgs {
         system = "x86_64-linux";
-        specialArgs = inputs;
-        modules =
-          [
-            {
-              networking.hostName = name;
+        crossSystem = {
+          config = "aarch64-unknown-linux-gnu";
+        };
 
-              nixpkgs.crossSystem = {
-                config = "aarch64-unknown-linux-gnu";
-              };
-            }
-
-            module
-            ./modules/configuration.nix
-          ];
-      })
-      self.nixosModules;
-
-    packages.x86_64-linux = {
-      # sdImage
-      sdImage-opi5 = self.nixosConfigurations.orangepi5.config.system.build.sdImage;
-      sdImage-opi5plus = self.nixosConfigurations.orangepi5plus.config.system.build.sdImage;
-      sdImage-rock5a = self.nixosConfigurations.rock5a.config.system.build.sdImage;
-
-      # the custom kernel for debugging
-      # use `nix develop` to enter the environment with the custom kernel build environment available.
-      # and then use `unpackPhase` to unpack the kernel source code and cd into it.
-      # then you can use `make menuconfig` to configure the kernel.
-      #
-      # problem
-      #   - using `make menuconfig` - Unable to find the ncurses package.
-      # Solution
-      #   - unpackPhase, and the use `nix develop .#fhsEnv` to enter the fhs test environment.
-      #   - Then use `make menuconfig` to configure the kernel.
-      kernel = pkgsKernel.linuxPackages_rockchip.kernel.dev;
-    };
-
-    # use `nix develop .#fhsEnv` to enter the fhs test environment defined here.
-    # for kernel debugging
-    devShells.x86_64-linux.fhsEnv = let
-      pkgs = import nixpkgs {
-        system = "x86_64-linux";
+        overlays = [
+          (self: super: {
+            linuxPackages_rockchip = super.linuxPackagesFor (super.callPackage ./pkgs/kernel/legacy.nix { });
+          })
+        ];
       };
     in
-      # the code here is mainly copied from:
-      #   https://nixos.wiki/wiki/Linux_kernel#Embedded_Linux_Cross-compile_xconfig_and_menuconfig
-      (pkgs.buildFHSUserEnv {
-        name = "kernel-build-env";
-        targetPkgs = pkgs_: (with pkgs_;
-          [
-            # we need theses packages to make `make menuconfig` work.
-            pkgconfig
-            ncurses
+    {
+      nixosModules = {
+        # Orange Pi 5 SBC
+        orangepi5 = import ./modules/boards/orangepi5.nix;
+        # Orange Pi 5 Plus SBC
+        # TODO not complete yet
+        orangepi5plus = import ./modules/boards/orangepi5plus.nix;
+        # Rock 5 Model A SBC
+        # TODO not complete yet
+        rock5a = import ./modules/boards/rock5a.nix;
+      };
 
-            # custom kernel
-            pkgsKernel.linuxPackages_rockchip.kernel
+      nixosConfigurations = builtins.mapAttrs
+        (name: module:
+          import "${nixpkgs}/nixos/lib/eval-config.nix" {
+            system = "x86_64-linux";
+            specialArgs = inputs;
+            modules =
+              [
+                {
+                  networking.hostName = name;
 
-            # arm64 cross-compilation toolchain
-            pkgsKernel.gccStdenv.cc
-            # native gcc
-            gcc
-          ]
-          ++ pkgs.linux.nativeBuildInputs);
-        runScript = pkgs.writeScript "init.sh" ''
-          # set the cross-compilation environment variables.
-          export CROSS_COMPILE=aarch64-unknown-linux-gnu-
-          export ARCH=arm64
-          export PKG_CONFIG_PATH="${pkgs.ncurses.dev}/lib/pkgconfig:"
-          exec bash
-        '';
-      }).env;
-  };
+                  nixpkgs.crossSystem = {
+                    config = "aarch64-unknown-linux-gnu";
+                  };
+                }
+
+                module
+                ./modules/configuration.nix
+              ];
+          })
+        self.nixosModules;
+
+      packages.x86_64-linux = {
+        # sdImage
+        sdImage-opi5 = self.nixosConfigurations.orangepi5.config.system.build.sdImage;
+        sdImage-opi5plus = self.nixosConfigurations.orangepi5plus.config.system.build.sdImage;
+        sdImage-rock5a = self.nixosConfigurations.rock5a.config.system.build.sdImage;
+
+        # the custom kernel for debugging
+        # use `nix develop` to enter the environment with the custom kernel build environment available.
+        # and then use `unpackPhase` to unpack the kernel source code and cd into it.
+        # then you can use `make menuconfig` to configure the kernel.
+        #
+        # problem
+        #   - using `make menuconfig` - Unable to find the ncurses package.
+        # Solution
+        #   - unpackPhase, and the use `nix develop .#fhsEnv` to enter the fhs test environment.
+        #   - Then use `make menuconfig` to configure the kernel.
+        kernel = pkgsKernel.linuxPackages_rockchip.kernel.dev;
+      };
+
+      # use `nix develop .#fhsEnv` to enter the fhs test environment defined here.
+      # for kernel debugging
+      devShells.x86_64-linux.fhsEnv =
+        let
+          pkgs = import nixpkgs {
+            system = "x86_64-linux";
+          };
+        in
+        # the code here is mainly copied from:
+          #   https://nixos.wiki/wiki/Linux_kernel#Embedded_Linux_Cross-compile_xconfig_and_menuconfig
+        (pkgs.buildFHSUserEnv {
+          name = "kernel-build-env";
+          targetPkgs = pkgs_: (with pkgs_;
+            [
+              # we need theses packages to make `make menuconfig` work.
+              pkgconfig
+              ncurses
+
+              # custom kernel
+              pkgsKernel.linuxPackages_rockchip.kernel
+
+              # arm64 cross-compilation toolchain
+              pkgsKernel.gccStdenv.cc
+              # native gcc
+              gcc
+            ]
+            ++ pkgs.linux.nativeBuildInputs);
+          runScript = pkgs.writeScript "init.sh" ''
+            # set the cross-compilation environment variables.
+            export CROSS_COMPILE=aarch64-unknown-linux-gnu-
+            export ARCH=arm64
+            export PKG_CONFIG_PATH="${pkgs.ncurses.dev}/lib/pkgconfig:"
+            exec bash
+          '';
+        }).env;
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
   in {
     nixosConfigurations = {
       # Orange Pi 5 SBC
-      orangepi5 = import "${nixpkgs}/nixos/lib/eval-config.nix" rec {
+      orangepi5 = import "${nixpkgs}/nixos/lib/eval-config.nix" {
         system = "x86_64-linux";
         specialArgs = inputs;
         modules =
@@ -41,13 +41,13 @@
             }
 
             ./modules/boards/orangepi5.nix
-            ./modules/user-group.nix
+            ./modules/configuration.nix
           ];
       };
 
       # Orange Pi 5 Plus SBC
       # TODO not complete yet
-      orangepi5plus = import "${nixpkgs}/nixos/lib/eval-config.nix" rec {
+      orangepi5plus = import "${nixpkgs}/nixos/lib/eval-config.nix" {
         system = "x86_64-linux";
         specialArgs = inputs;
         modules =
@@ -61,13 +61,13 @@
             }
 
             ./modules/boards/orangepi5plus.nix
-            ./modules/user-group.nix
+            ./modules/configuration.nix
           ];
       };
 
       # Rock 5 Model A SBC
       # TODO not complete yet
-      rock5a = import "${nixpkgs}/nixos/lib/eval-config.nix" rec {
+      rock5a = import "${nixpkgs}/nixos/lib/eval-config.nix" {
         system = "x86_64-linux";
         specialArgs = inputs;
         modules =
@@ -81,7 +81,7 @@
             }
 
             ./modules/boards/rock5a.nix
-            ./modules/user-group.nix
+            ./modules/configuration.nix
           ];
       };
     };
@@ -96,7 +96,7 @@
       # use `nix develop` to enter the environment with the custom kernel build environment available.
       # and then use `unpackPhase` to unpack the kernel source code and cd into it.
       # then you can use `make menuconfig` to configure the kernel.
-      # 
+      #
       # problem
       #   - using `make menuconfig` - Unable to find the ncurses package.
       # Solution

--- a/flake.nix
+++ b/flake.nix
@@ -25,66 +25,36 @@
       ];
     };
   in {
-    nixosConfigurations = {
+    nixosModules = {
       # Orange Pi 5 SBC
-      orangepi5 = import "${nixpkgs}/nixos/lib/eval-config.nix" {
-        system = "x86_64-linux";
-        specialArgs = inputs;
-        modules =
-          [
-            {
-              networking.hostName = "orangepi5";
-
-              nixpkgs.crossSystem = {
-                config = "aarch64-unknown-linux-gnu";
-              };
-            }
-
-            ./modules/boards/orangepi5.nix
-            ./modules/configuration.nix
-          ];
-      };
-
+      orangepi5 = import ./modules/boards/orangepi5.nix;
       # Orange Pi 5 Plus SBC
       # TODO not complete yet
-      orangepi5plus = import "${nixpkgs}/nixos/lib/eval-config.nix" {
-        system = "x86_64-linux";
-        specialArgs = inputs;
-        modules =
-          [
-            {
-              networking.hostName = "orangepi5plus";
-
-              nixpkgs.crossSystem = {
-                config = "aarch64-unknown-linux-gnu";
-              };
-            }
-
-            ./modules/boards/orangepi5plus.nix
-            ./modules/configuration.nix
-          ];
-      };
-
+      orangepi5plus = import ./modules/boards/orangepi5plus.nix;
       # Rock 5 Model A SBC
       # TODO not complete yet
-      rock5a = import "${nixpkgs}/nixos/lib/eval-config.nix" {
+      rock5a = import ./modules/boards/rock5a.nix;
+    };
+
+    nixosConfigurations = builtins.mapAttrs (name: module:
+      import "${nixpkgs}/nixos/lib/eval-config.nix" {
         system = "x86_64-linux";
         specialArgs = inputs;
         modules =
           [
             {
-              networking.hostName = "rock5a";
+              networking.hostName = name;
 
               nixpkgs.crossSystem = {
                 config = "aarch64-unknown-linux-gnu";
               };
             }
 
-            ./modules/boards/rock5a.nix
+            module
             ./modules/configuration.nix
           ];
-      };
-    };
+      })
+      self.nixosModules;
 
     packages.x86_64-linux = {
       # sdImage

--- a/flake.nix
+++ b/flake.nix
@@ -40,15 +40,12 @@
         (name: module:
           import "${nixpkgs}/nixos/lib/eval-config.nix" {
             system = "x86_64-linux";
-            specialArgs = inputs;
+            specialArgs.rk3588 = { inherit (inputs) nixpkgs mesa-panfork; };
             modules =
               [
                 {
                   networking.hostName = name;
-
-                  nixpkgs.crossSystem = {
-                    config = "aarch64-unknown-linux-gnu";
-                  };
+                  nixpkgs.crossSystem.config = "aarch64-unknown-linux-gnu";
                 }
 
                 module

--- a/modules/boards/base.nix
+++ b/modules/boards/base.nix
@@ -1,9 +1,13 @@
 { lib
 , pkgs
-, mesa-panfork
+, rk3588
 , ...
 }:
 
+
+let
+  inherit (rk3588) mesa-panfork;
+in
 {
   # =========================================================================
   #      Base NixOS Configuration

--- a/modules/boards/base.nix
+++ b/modules/boards/base.nix
@@ -3,42 +3,12 @@
   pkgs,
   mesa-panfork,
   ...
-}: 
+}:
 
 {
   # =========================================================================
   #      Base NixOS Configuration
   # =========================================================================
-
-  nix.settings = {
-    experimental-features = ["nix-command" "flakes"];
-  };
-
-  # List packages installed in system profile. To search, run:
-  # $ nix search wget
-  environment.systemPackages = with pkgs; [
-    git      # used by nix flakes
-    curl
-
-    neofetch
-    lm_sensors  # `sensors`
-    btop     # monitor system resources
-
-    # Peripherals
-    mtdutils
-    i2c-tools
-    minicom
-  ];
-
-  # Enable the OpenSSH daemon.
-  services.openssh = {
-    enable = lib.mkDefault true;
-    settings = {
-      X11Forwarding = lib.mkDefault true;
-      PasswordAuthentication = lib.mkDefault true;
-    };
-    openFirewall = lib.mkDefault true;
-  };
 
   boot = {
     # Some filesystems (e.g. zfs) have some trouble with cross (or with BSP kernels?) here.
@@ -51,21 +21,21 @@
     ];
 
     loader = {
-      grub.enable = false;
-      generic-extlinux-compatible.enable = true;
+      grub.enable = lib.mkForce false;
+      generic-extlinux-compatible.enable = lib.mkForce true;
     };
 
-    initrd.includeDefaultModules = false;
+    initrd.includeDefaultModules = lib.mkForce false;
     initrd.availableKernelModules = lib.mkForce [ "dm_mod" "dm_crypt" "encrypted_keys" ];
   };
 
-  powerManagement.cpuFreqGovernor = "ondemand";
+  powerManagement.cpuFreqGovernor = lib.mkDefault "ondemand";
 
   hardware = {
     # driver & firmware for Mali-G610 GPU
     # it works on all rk2588/rk3588s based SBCs.
     opengl = {
-      enable = true;
+      enable = lib.mkDefault true;
       package =
         lib.mkForce
         (
@@ -82,7 +52,7 @@
         .drivers;
     };
 
-    enableRedistributableFirmware = true;
+    enableRedistributableFirmware = lib.mkForce true;
     firmware = [
       # firmware for Mali-G610 GPU
       (pkgs.callPackage ../../pkgs/mali-firmware {})
@@ -95,5 +65,5 @@
   # this value at the release version of the first install of this system.
   # Before changing this value read the documentation for this option
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-  system.stateVersion = "23.05"; # Did you read the comment?
+  system.stateVersion = lib.mkDefault "23.05"; # Did you read the comment?
 }

--- a/modules/boards/base.nix
+++ b/modules/boards/base.nix
@@ -1,8 +1,7 @@
-{
-  lib,
-  pkgs,
-  mesa-panfork,
-  ...
+{ lib
+, pkgs
+, mesa-panfork
+, ...
 }:
 
 {
@@ -38,24 +37,22 @@
       enable = lib.mkDefault true;
       package =
         lib.mkForce
-        (
-          (pkgs.mesa.override {
-            galliumDrivers = ["panfrost" "swrast"];
-            vulkanDrivers = ["swrast"];
-          })
-          .overrideAttrs (_: {
-            pname = "mesa-panfork";
-            version = "23.0.0-panfork";
-            src = mesa-panfork;
-          })
-        )
-        .drivers;
+          (
+            (pkgs.mesa.override {
+              galliumDrivers = [ "panfrost" "swrast" ];
+              vulkanDrivers = [ "swrast" ];
+            }).overrideAttrs (_: {
+              pname = "mesa-panfork";
+              version = "23.0.0-panfork";
+              src = mesa-panfork;
+            })
+          ).drivers;
     };
 
     enableRedistributableFirmware = lib.mkForce true;
     firmware = [
       # firmware for Mali-G610 GPU
-      (pkgs.callPackage ../../pkgs/mali-firmware {})
+      (pkgs.callPackage ../../pkgs/mali-firmware { })
     ];
   };
 

--- a/modules/boards/orangepi5.nix
+++ b/modules/boards/orangepi5.nix
@@ -3,11 +3,13 @@
 # =========================================================================
 { config
 , pkgs
-, nixpkgs
+, rk3588
 , ...
 }:
 
 let
+  inherit (rk3588) nixpkgs;
+
   boardName = "orangepi5";
   rootPartitionUUID = "14e19a7b-0ae0-484d-9d54-43bd6fdc20c7";
 in

--- a/modules/boards/orangepi5.nix
+++ b/modules/boards/orangepi5.nix
@@ -1,12 +1,11 @@
 # =========================================================================
 #      Orange Pi 5 Specific Configuration
 # =========================================================================
-{
-  config,
-  pkgs,
-  nixpkgs,
-  ...
-}: 
+{ config
+, pkgs
+, nixpkgs
+, ...
+}:
 
 let
   boardName = "orangepi5";
@@ -19,7 +18,7 @@ in
   ];
 
   boot = {
-    kernelPackages = pkgs.linuxPackagesFor (pkgs.callPackage ../../pkgs/kernel/legacy.nix {});
+    kernelPackages = pkgs.linuxPackagesFor (pkgs.callPackage ../../pkgs/kernel/legacy.nix { });
 
     # kernelParams copy from Armbian's /boot/armbianEnv.txt & /boot/boot.cmd
     kernelParams = [
@@ -27,10 +26,10 @@ in
       "rootwait"
       "rootfstype=ext4"
 
-      "earlycon"  # enable early console, so we can see the boot messages via serial port / HDMI
-      "consoleblank=0"  # disable console blanking(screen saver)
+      "earlycon" # enable early console, so we can see the boot messages via serial port / HDMI
+      "consoleblank=0" # disable console blanking(screen saver)
       "console=ttyS2,1500000" # serial port
-      "console=tty1"          # HDMI
+      "console=tty1" # HDMI
 
       # docker optimizations
       "cgroup_enable=cpuset"

--- a/modules/boards/orangepi5plus.nix
+++ b/modules/boards/orangepi5plus.nix
@@ -1,12 +1,11 @@
 # =========================================================================
 #      Orange Pi 5 Plus Specific Configuration
 # =========================================================================
-{
-  config,
-  pkgs,
-  nixpkgs,
-  ...
-}: 
+{ config
+, pkgs
+, nixpkgs
+, ...
+}:
 
 let
   boardName = "orangepi5plus";
@@ -19,7 +18,7 @@ in
   ];
 
   boot = {
-    kernelPackages = pkgs.linuxPackagesFor (pkgs.callPackage ../../pkgs/kernel/legacy.nix {});
+    kernelPackages = pkgs.linuxPackagesFor (pkgs.callPackage ../../pkgs/kernel/legacy.nix { });
 
     # kernelParams copy from Armbian's /boot/armbianEnv.txt & /boot/boot.cmd
     kernelParams = [
@@ -27,10 +26,10 @@ in
       "rootwait"
       "rootfstype=ext4"
 
-      "earlycon"  # enable early console, so we can see the boot messages via serial port / HDMI
-      "consoleblank=0"  # disable console blanking(screen saver)
+      "earlycon" # enable early console, so we can see the boot messages via serial port / HDMI
+      "consoleblank=0" # disable console blanking(screen saver)
       "console=ttyS2,1500000" # serial port
-      "console=tty1"          # HDMI
+      "console=tty1" # HDMI
 
       # docker optimizations
       "cgroup_enable=cpuset"

--- a/modules/boards/orangepi5plus.nix
+++ b/modules/boards/orangepi5plus.nix
@@ -3,11 +3,13 @@
 # =========================================================================
 { config
 , pkgs
-, nixpkgs
+, rk3588
 , ...
 }:
 
 let
+  inherit (rk3588) nixpkgs;
+
   boardName = "orangepi5plus";
   rootPartitionUUID = "14e19a7b-0ae0-484d-9d54-43bd6fdc20c7";
 in

--- a/modules/boards/rock5a.nix
+++ b/modules/boards/rock5a.nix
@@ -4,10 +4,12 @@
 { lib
 , config
 , pkgs
-, nixpkgs
+, rk3588
 , ...
 }:
 let
+  inherit (rk3588) nixpkgs;
+
   boardName = "rock5a";
   rootPartitionUUID = "14e19a7b-0ae0-484d-9d54-43bd6fdc20c7";
   # rkbin-rk3588 = pkgs.callPackage ../../pkgs/rkbin-rk3588 {};

--- a/modules/boards/rock5a.nix
+++ b/modules/boards/rock5a.nix
@@ -1,18 +1,19 @@
 # =========================================================================
 #      Rock 5 Model A Specific Configuration
 # =========================================================================
-{
-  lib,
-  config,
-  pkgs,
-  nixpkgs,
-  ...
-}: let
+{ lib
+, config
+, pkgs
+, nixpkgs
+, ...
+}:
+let
   boardName = "rock5a";
   rootPartitionUUID = "14e19a7b-0ae0-484d-9d54-43bd6fdc20c7";
   # rkbin-rk3588 = pkgs.callPackage ../../pkgs/rkbin-rk3588 {};
-  uboot = pkgs.callPackage ../../pkgs/u-boot/radxa-prebuilt.nix {};
-in {
+  uboot = pkgs.callPackage ../../pkgs/u-boot/radxa-prebuilt.nix { };
+in
+{
   imports = [
     ./base.nix
     ../sd-image-rockchip.nix
@@ -21,7 +22,7 @@ in {
   ];
 
   boot = {
-    kernelPackages = pkgs.linuxPackagesFor (pkgs.callPackage ../../pkgs/kernel/legacy.nix {});
+    kernelPackages = pkgs.linuxPackagesFor (pkgs.callPackage ../../pkgs/kernel/legacy.nix { });
 
     # kernelParams copy from rock5a's official debian image's /boot/extlinux/extlinux.conf
     # https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html
@@ -82,7 +83,7 @@ in {
     imageBaseName = "${boardName}-sd-image";
     compressImage = true;
 
-    firmwarePartitionOffset = 32; 
+    firmwarePartitionOffset = 32;
     populateFirmwareCommands = "";
 
     populateRootCommands = ''

--- a/modules/configuration.nix
+++ b/modules/configuration.nix
@@ -1,6 +1,5 @@
-{
-  pkgs,
-  ...
+{ pkgs
+, ...
 }:
 
 let
@@ -13,18 +12,18 @@ let
 in
 {
   nix.settings = {
-    experimental-features = ["nix-command" "flakes"];
+    experimental-features = [ "nix-command" "flakes" ];
   };
 
   # List packages installed in system profile. To search, run:
   # $ nix search wget
   environment.systemPackages = with pkgs; [
-    git      # used by nix flakes
+    git # used by nix flakes
     curl
 
     neofetch
-    lm_sensors  # `sensors`
-    btop     # monitor system resources
+    lm_sensors # `sensors`
+    btop # monitor system resources
 
     # Peripherals
     mtdutils
@@ -51,7 +50,7 @@ in
     inherit hashedPassword;
     isNormalUser = true;
     home = "/home/${username}";
-    extraGroups = [ "users" "networkmanager" "wheel" "video" "docker"];
+    extraGroups = [ "users" "networkmanager" "wheel" "video" "docker" ];
     openssh.authorizedKeys.keys = [
       publickey
     ];
@@ -62,7 +61,7 @@ in
   ];
 
   users.groups = {
-    "${username}" = {};
-    docker = {};
+    "${username}" = { };
+    docker = { };
   };
 }

--- a/modules/configuration.nix
+++ b/modules/configuration.nix
@@ -1,3 +1,8 @@
+{
+  pkgs,
+  ...
+}:
+
 let
   username = "rk";
   # To generate a hashed password run `mkpasswd`.
@@ -7,6 +12,36 @@ let
   publickey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3F3AH/vKnA2vxl72h67fcxhIK8l+7F/bdE1zmtwTVU ryan@romantic";
 in
 {
+  nix.settings = {
+    experimental-features = ["nix-command" "flakes"];
+  };
+
+  # List packages installed in system profile. To search, run:
+  # $ nix search wget
+  environment.systemPackages = with pkgs; [
+    git      # used by nix flakes
+    curl
+
+    neofetch
+    lm_sensors  # `sensors`
+    btop     # monitor system resources
+
+    # Peripherals
+    mtdutils
+    i2c-tools
+    minicom
+  ];
+
+  # Enable the OpenSSH daemon.
+  services.openssh = {
+    enable = true;
+    settings = {
+      X11Forwarding = true;
+      PasswordAuthentication = true;
+    };
+    openFirewall = true;
+  };
+
   # =========================================================================
   #      Users & Groups NixOS Configuration
   # =========================================================================

--- a/modules/sd-image-rockchip.nix
+++ b/modules/sd-image-rockchip.nix
@@ -177,98 +177,106 @@ in
 
     sdImage.storePaths = [ config.system.build.toplevel ];
 
-    system.build.sdImage = pkgs.callPackage ({ stdenv, dosfstools, e2fsprogs,
-    mtools, libfaketime, util-linux, zstd }: stdenv.mkDerivation {
-      name = config.sdImage.imageName;
+    system.build.sdImage = pkgs.callPackage
+      ({ stdenv
+       , dosfstools
+       , e2fsprogs
+       , mtools
+       , libfaketime
+       , util-linux
+       , zstd
+       }: stdenv.mkDerivation {
+        name = config.sdImage.imageName;
 
-      nativeBuildInputs = [ dosfstools e2fsprogs libfaketime mtools util-linux ]
-      ++ lib.optional config.sdImage.compressImage zstd;
+        nativeBuildInputs = [ dosfstools e2fsprogs libfaketime mtools util-linux ]
+          ++ lib.optional config.sdImage.compressImage zstd;
 
-      inherit (config.sdImage) imageName compressImage;
+        inherit (config.sdImage) imageName compressImage;
 
-      buildCommand = ''
-        mkdir -p $out/nix-support $out/sd-image
-        export img=$out/sd-image/${config.sdImage.imageName}
+        buildCommand = ''
+          mkdir -p $out/nix-support $out/sd-image
+          export img=$out/sd-image/${config.sdImage.imageName}
 
-        echo "${pkgs.stdenv.buildPlatform.system}" > $out/nix-support/system
-        if test -n "$compressImage"; then
-          echo "file sd-image $img.zst" >> $out/nix-support/hydra-build-products
-        else
-          echo "file sd-image $img" >> $out/nix-support/hydra-build-products
-        fi
+          echo "${pkgs.stdenv.buildPlatform.system}" > $out/nix-support/system
+          if test -n "$compressImage"; then
+            echo "file sd-image $img.zst" >> $out/nix-support/hydra-build-products
+          else
+            echo "file sd-image $img" >> $out/nix-support/hydra-build-products
+          fi
 
-        root_fs=${rootfsImage}
-        ${lib.optionalString config.sdImage.compressImage ''
-        root_fs=./root-fs.img
-        echo "Decompressing rootfs image"
-        zstd -d --no-progress "${rootfsImage}" -o $root_fs
-        ''}
+          root_fs=${rootfsImage}
+          ${lib.optionalString config.sdImage.compressImage ''
+          root_fs=./root-fs.img
+          echo "Decompressing rootfs image"
+          zstd -d --no-progress "${rootfsImage}" -o $root_fs
+          ''}
 
-        # Gap in front of the first partition, in MiB
-        gap=${toString config.sdImage.firmwarePartitionOffset}
+          # Gap in front of the first partition, in MiB
+          gap=${toString config.sdImage.firmwarePartitionOffset}
 
-        # Create the image file sized to fit /boot/firmware and /, plus slack for the gap.
-        rootSizeBlocks=$(du -B 512 --apparent-size $root_fs | awk '{ print $1 }')
-        firmwareSizeBlocks=$((${toString config.sdImage.firmwareSize} * 1024 * 1024 / 512))
-        imageSize=$((rootSizeBlocks * 512 + firmwareSizeBlocks * 512 + gap * 1024 * 1024))
-        truncate -s $imageSize $img
+          # Create the image file sized to fit /boot/firmware and /, plus slack for the gap.
+          rootSizeBlocks=$(du -B 512 --apparent-size $root_fs | awk '{ print $1 }')
+          firmwareSizeBlocks=$((${toString config.sdImage.firmwareSize} * 1024 * 1024 / 512))
+          imageSize=$((rootSizeBlocks * 512 + firmwareSizeBlocks * 512 + gap * 1024 * 1024))
+          truncate -s $imageSize $img
 
-        # Have to use GPT for the disk table, otherwise licheepi's u-boot will report:
-        #    ** Unrecognized filesystem type **
-        # 
-        # The "bootable" partition is where u-boot will look file for the bootloader
-        # information (dtbs, extlinux.conf file).
-        #
-        # Lichee Pi 4A will boot from its builtin spl flash first, so we don't need to
-        # set the bootable flag on the first partition.
-        sfdisk $img <<EOF
-            label: gpt
-            label-id: ${config.sdImage.firmwarePartitionID}
-            unit: sectors
-            sector-size: 512
+          # Have to use GPT for the disk table, otherwise licheepi's u-boot will report:
+          #    ** Unrecognized filesystem type **
+          # 
+          # The "bootable" partition is where u-boot will look file for the bootloader
+          # information (dtbs, extlinux.conf file).
+          #
+          # Lichee Pi 4A will boot from its builtin spl flash first, so we don't need to
+          # set the bootable flag on the first partition.
+          sfdisk $img <<EOF
+              label: gpt
+              label-id: ${config.sdImage.firmwarePartitionID}
+              unit: sectors
+              sector-size: 512
 
-            start=''${gap}M, size=$firmwareSizeBlocks, type=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
-            start=$((gap + ${toString config.sdImage.firmwareSize}))M, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, bootable
-        EOF
+              start=''${gap}M, size=$firmwareSizeBlocks, type=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
+              start=$((gap + ${toString config.sdImage.firmwareSize}))M, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, bootable
+          EOF
 
-        # Copy the rootfs into the SD image
-        fsck.ext4 -vn $root_fs
-        eval $(partx $img -o START,SECTORS --nr 2 --pairs)
-        dd conv=notrunc if=$root_fs of=$img seek=$START count=$SECTORS
+          # Copy the rootfs into the SD image
+          fsck.ext4 -vn $root_fs
+          eval $(partx $img -o START,SECTORS --nr 2 --pairs)
+          dd conv=notrunc if=$root_fs of=$img seek=$START count=$SECTORS
 
-        # Create a FAT32 /boot/firmware partition of suitable size into firmware_part.img
-        eval $(partx $img -o START,SECTORS --nr 1 --pairs)
-        truncate -s $((SECTORS * 512)) firmware_part.img
+          # Create a FAT32 /boot/firmware partition of suitable size into firmware_part.img
+          eval $(partx $img -o START,SECTORS --nr 1 --pairs)
+          truncate -s $((SECTORS * 512)) firmware_part.img
 
-        mkfs.vfat -i ${config.sdImage.firmwarePartitionID} -n ${config.sdImage.firmwarePartitionName} firmware_part.img
+          mkfs.vfat -i ${config.sdImage.firmwarePartitionID} -n ${config.sdImage.firmwarePartitionName} firmware_part.img
 
-        # Populate the files intended for /boot/firmware
-        mkdir firmware
-        ${config.sdImage.populateFirmwareCommands}
+          # Populate the files intended for /boot/firmware
+          mkdir firmware
+          ${config.sdImage.populateFirmwareCommands}
 
-        find firmware -exec touch --date=2000-01-01 {} +
-        # Copy the populated /boot/firmware into the SD image
-        cd firmware
-        # Force a fixed order in mcopy for better determinism, and avoid file globbing
-        for d in $(find . -type d -mindepth 1 | sort); do
-          faketime "2000-01-01 00:00:00" mmd -i ../firmware_part.img "::/$d"
-        done
-        for f in $(find . -type f | sort); do
-          mcopy -pvm -i ../firmware_part.img "$f" "::/$f"
-        done
-        cd ..
+          find firmware -exec touch --date=2000-01-01 {} +
+          # Copy the populated /boot/firmware into the SD image
+          cd firmware
+          # Force a fixed order in mcopy for better determinism, and avoid file globbing
+          for d in $(find . -type d -mindepth 1 | sort); do
+            faketime "2000-01-01 00:00:00" mmd -i ../firmware_part.img "::/$d"
+          done
+          for f in $(find . -type f | sort); do
+            mcopy -pvm -i ../firmware_part.img "$f" "::/$f"
+          done
+          cd ..
 
-        # Verify the FAT partition before copying it.
-        fsck.vfat -vn firmware_part.img
-        dd conv=notrunc if=firmware_part.img of=$img seek=$START count=$SECTORS
+          # Verify the FAT partition before copying it.
+          fsck.vfat -vn firmware_part.img
+          dd conv=notrunc if=firmware_part.img of=$img seek=$START count=$SECTORS
 
-        ${config.sdImage.postBuildCommands}
+          ${config.sdImage.postBuildCommands}
 
-        if test -n "$compressImage"; then
-            zstd -T$NIX_BUILD_CORES --rm $img
-        fi
-      '';
-    }) {};
+          if test -n "$compressImage"; then
+              zstd -T$NIX_BUILD_CORES --rm $img
+          fi
+        '';
+      })
+      { };
 
     boot.postBootCommands = lib.mkIf config.sdImage.expandOnBoot ''
       # On the first boot do some maintenance tasks

--- a/modules/sd-image-rockchip.nix
+++ b/modules/sd-image-rockchip.nix
@@ -24,8 +24,7 @@ with lib;
 
 let
   rootfsImage = pkgs.callPackage "${modulesPath}/../lib/make-ext4-fs.nix" ({
-    inherit (config.sdImage) storePaths;
-    compressImage = config.sdImage.compressImage;
+    inherit (config.sdImage) storePaths compressImage;
     populateImageCommands = config.sdImage.populateRootCommands;
     volumeLabel = "NIXOS_SD";
   } // optionalAttrs (config.sdImage.rootPartitionUUID != null) {
@@ -222,7 +221,7 @@ in
 
           # Have to use GPT for the disk table, otherwise licheepi's u-boot will report:
           #    ** Unrecognized filesystem type **
-          # 
+          #
           # The "bootable" partition is where u-boot will look file for the bootloader
           # information (dtbs, extlinux.conf file).
           #

--- a/pkgs/kernel/collabora.nix
+++ b/pkgs/kernel/collabora.nix
@@ -8,12 +8,10 @@
 # If you already have a generated configuration file, you can build a kernel that uses it with pkgs.linuxManualConfig
 # The difference between deconfig and the generated configuration file is that the generated configuration file is more complete,
 # 
-{
-
-  fetchzip,
-  linuxManualConfig,
-  ubootTools,
-  ...
+{ fetchzip
+, linuxManualConfig
+, ubootTools
+, ...
 }:
 (linuxManualConfig {
   version = "6.5-collabora-rk3588";
@@ -23,9 +21,9 @@
     # branch: rk3588
     # date: 2023-07-21
     url = "https://gitlab.collabora.com/hardware-enablement/rockchip-3588/linux/-/archive/7a5aac740d804bf907bb3781c011a051fdcabd7e/linux-7a5aac740d804bf907bb3781c011a051fdcabd7e.zip";
-    sha256 ="";
+    sha256 = "";
   };
-  
+
   # Path to the generated kernel config file
   # 
   # You can generate the kernel config file based on the defconfig.
@@ -47,8 +45,7 @@
   extraMeta.branch = "5.10";
 
   allowImportFromDerivation = true;
-})
-.overrideAttrs (old: {
+}).overrideAttrs (old: {
   name = "k"; # dodge uboot length limits
-  nativeBuildInputs = old.nativeBuildInputs ++ [ubootTools];
+  nativeBuildInputs = old.nativeBuildInputs ++ [ ubootTools ];
 })

--- a/pkgs/kernel/legacy.nix
+++ b/pkgs/kernel/legacy.nix
@@ -8,11 +8,10 @@
 # If you already have a generated configuration file, you can build a kernel that uses it with pkgs.linuxManualConfig
 # The difference between deconfig and the generated configuration file is that the generated configuration file is more complete,
 # 
-{
-  fetchzip,
-  linuxManualConfig,
-  ubootTools,
-  ...
+{ fetchzip
+, linuxManualConfig
+, ubootTools
+, ...
 }:
 (linuxManualConfig {
   version = "5.10.160-armbian-rk3588";
@@ -23,7 +22,7 @@
     # branch: rk-5.10-rkr4
     # date: 2023-08-08
     url = "https://github.com/armbian/linux-rockchip/archive/8cae9a3e884071996260905575b55136e2480f6b.zip";
-    sha256 ="sha256-9pp9OXRMY8RUq4Fn5AcYhiGeyXXDPRAm9fUVzQV5L2k=";
+    sha256 = "sha256-9pp9OXRMY8RUq4Fn5AcYhiGeyXXDPRAm9fUVzQV5L2k=";
   };
 
   # Path to the generated kernel config file
@@ -47,8 +46,7 @@
   extraMeta.branch = "5.10";
 
   allowImportFromDerivation = true;
-})
-.overrideAttrs (old: {
+}).overrideAttrs (old: {
   name = "k"; # dodge uboot length limits
-  nativeBuildInputs = old.nativeBuildInputs ++ [ubootTools];
+  nativeBuildInputs = old.nativeBuildInputs ++ [ ubootTools ];
 })

--- a/pkgs/mali-firmware/default.nix
+++ b/pkgs/mali-firmware/default.nix
@@ -1,6 +1,6 @@
-{
-  stdenv,
-  fetchurl,
+{ stdenv
+, fetchurl
+,
 }:
 stdenv.mkDerivation {
   pname = "mali-g610-firmware";

--- a/pkgs/u-boot/radxa-prebuilt.nix
+++ b/pkgs/u-boot/radxa-prebuilt.nix
@@ -1,5 +1,5 @@
-{
-  stdenv,
+{ stdenv
+,
 }:
 
 let
@@ -8,7 +8,7 @@ let
   # And the unpack `output/debs/linux-u-boot-rock-5a-legacy_xxx.deb` to get the files below.
   idbloader_img = ./linux-u-boot-legacy-rock-5a/idbloader.img;
   u_boot_itb = ./linux-u-boot-legacy-rock-5a/u-boot.itb;
-in 
+in
 stdenv.mkDerivation {
   pname = "u-boot-prebuilt";
   version = "unstable-2023-08-27";

--- a/pkgs/u-boot/radxa.nix
+++ b/pkgs/u-boot/radxa.nix
@@ -1,11 +1,10 @@
 # TODO not working yet!
-{ lib
-, buildUBoot
+{ buildUBoot
 , fetchFromGitHub
 , rkbin-rk3588
-,
+, ...
 }:
-(buildUBoot rec {
+(buildUBoot {
   version = "2023.08.27";
 
   # https://github.com/radxa/u-boot/tree/stable-5.10-rock5
@@ -39,6 +38,6 @@
     "idbloader.img"
   ];
 
-}).overrideAttrs (oldAttrs: {
+}).overrideAttrs (_oldAttrs: {
   patches = [ ]; # remove all patches, which is not compatible with thead-u-boot
 })

--- a/pkgs/u-boot/radxa.nix
+++ b/pkgs/u-boot/radxa.nix
@@ -1,9 +1,9 @@
 # TODO not working yet!
-{
-  lib,
-  buildUBoot,
-  fetchFromGitHub,
-  rkbin-rk3588,
+{ lib
+, buildUBoot
+, fetchFromGitHub
+, rkbin-rk3588
+,
 }:
 (buildUBoot rec {
   version = "2023.08.27";
@@ -19,8 +19,8 @@
   # https://github.com/radxa/u-boot/blob/stable-5.10-rock5/configs/rock-5a-rk3588s_defconfig
   defconfig = "rock-5a-rk3588s_defconfig";
 
-  extraMeta.platforms = ["aarch64-linux"];
-  BL31="${rkbin-rk3588}/rk3588_bl31_v1.38.elf";
+  extraMeta.platforms = [ "aarch64-linux" ];
+  BL31 = "${rkbin-rk3588}/rk3588_bl31_v1.38.elf";
 
   buildPhase = ''
     make -j20 CROSS_COMPILE=aarch64-unknown-linux-gnu- \
@@ -40,5 +40,5 @@
   ];
 
 }).overrideAttrs (oldAttrs: {
-  patches = [];  # remove all patches, which is not compatible with thead-u-boot
+  patches = [ ]; # remove all patches, which is not compatible with thead-u-boot
 })


### PR DESCRIPTION
This pr is a messy a bit, because it does everything. Better look at individual commits.

Overall, it started off with removing unnecessary defaults in the first commit and better export of nixos modules in the second one.

Latter commits are misc, they just do formatting of nix files and add pre commit hooks (with default `nix develop` environment) with linting (you can also lint and check formatting with `nix flake check` now).

I can split the first 2 commits and latter ones in separate pull request if you want, but I just found it easier for now.