### PR TITLE
Modularize mali firmware and update it to latest, fixing OpenCL on Jellyfin

### DIFF
--- a/modules/boards/base.nix
+++ b/modules/boards/base.nix
@@ -1,89 +1,105 @@
 {
   lib,
   pkgs,
+  config,
+  options,
   ...
 }: {
-  # =========================================================================
-  #      Base NixOS Configuration
-  # =========================================================================
-
-  powerManagement.cpuFreqGovernor = lib.mkDefault "ondemand";
-
-  boot = {
-    supportedFilesystems = lib.mkForce [
-      "vfat"
-      "fat32"
-      "exfat"
-      "ext4"
-      "btrfs"
-    ];
-
-    # Some default kernel modules are not available in our kernel,
-    # so we have not to include them in the initrd.
-    # All the default modules are listed here:
-    #   https://github.com/NixOS/nixpkgs/blob/nixos-23.11/nixos/modules/system/boot/kernel.nix#L257
-    #
-    # How I found this out:
-    #   ```
-    #   $ grep -r 'includeDefaultModules' ./nixpkgs/
-    #   /etc/nix/inputs/nixpkgs/nixos/modules/system/boot/kernel.nix:    boot.initrd.includeDefaultModules = mkOption {
-    #   /etc/nix/inputs/nixpkgs/nixos/modules/system/boot/kernel.nix:          optionals config.boot.initrd.includeDefaultModules ([
-    #   /etc/nix/inputs/nixpkgs/nixos/modules/system/boot/kernel.nix:          optionals config.boot.initrd.includeDefaultModules [
-    #   ````
-    initrd.includeDefaultModules = lib.mkForce false;
-    # Instead, we include only the modules we need for booting.
-    # NOTE: this is just the modules for booting, not the modules for the system!
-    # So you don't need to worry about missing modules for your hardware.
-    #
-    # To find out which modules you may need:
-    #   ```
-    #    $ grep -r 'availableKernelModules' ./nixpkgs/
-    #   ```
-    initrd.availableKernelModules = lib.mkForce [
-      # NVMe
-      "nvme"
-
-      # SD cards and internal eMMC drives.
-      "mmc_block"
-
-      # Support USB keyboards, in case the boot fails and we only have
-      # a USB keyboard, or for LUKS passphrase prompt.
-      "hid"
-
-      # For LUKS encrypted root partition.
-      # https://github.com/NixOS/nixpkgs/blob/nixos-23.11/nixos/modules/system/boot/luksroot.nix#L985
-      "dm_mod" # for LVM & LUKS
-      "dm_crypt" # for LUKS
-      "input_leds"
-    ];
+  options.hardware.mali = {
+    enableFirmware = lib.mkOption {
+      type = lib.types.bool;
+      description = "Whether to enable GPU firmware";
+      default = true;
+    };
+    firmwarePackage = lib.mkOption {
+      type = lib.types.package;
+      description = "Firmware package for Mali-G610 GPU";
+      default = (pkgs.callPackage ../../pkgs/mali-firmware {});
+    };
   };
 
-  hardware = {
-    # driver & firmware for Mali-G610 GPU
-    # it works on all rk2588/rk3588s based SBCs.
-    opengl.package =
-      (
-        (pkgs.mesa.override {
-          galliumDrivers = ["panfrost" "swrast"];
-          vulkanDrivers = ["swrast"];
-        })
-        .overrideAttrs (_: {
-          pname = "mesa-panfork";
-          version = "23.0.0-panfork";
-          src = pkgs.fetchFromGitLab {
-            owner = "panfork";
-            repo = "mesa";
-            rev = "120202c675749c5ef81ae4c8cdc30019b4de08f4"; # branch: csf
-            hash = "sha256-4eZHMiYS+sRDHNBtLZTA8ELZnLns7yT3USU5YQswxQ0=";
-          };
-        })
-      )
-      .drivers;
+  config = {
+    # =========================================================================
+    #      Base NixOS Configuration
+    # =========================================================================
 
-    enableRedistributableFirmware = lib.mkForce true;
-    firmware = [
-      # firmware for Mali-G610 GPU
-      (pkgs.callPackage ../../pkgs/mali-firmware {})
-    ];
+    powerManagement.cpuFreqGovernor = lib.mkDefault "ondemand";
+
+    boot = {
+      supportedFilesystems = lib.mkForce [
+        "vfat"
+        "fat32"
+        "exfat"
+        "ext4"
+        "btrfs"
+      ];
+
+      # Some default kernel modules are not available in our kernel,
+      # so we have not to include them in the initrd.
+      # All the default modules are listed here:
+      #   https://github.com/NixOS/nixpkgs/blob/nixos-23.11/nixos/modules/system/boot/kernel.nix#L257
+      #
+      # How I found this out:
+      #   ```
+      #   $ grep -r 'includeDefaultModules' ./nixpkgs/
+      #   /etc/nix/inputs/nixpkgs/nixos/modules/system/boot/kernel.nix:    boot.initrd.includeDefaultModules = mkOption {
+      #   /etc/nix/inputs/nixpkgs/nixos/modules/system/boot/kernel.nix:          optionals config.boot.initrd.includeDefaultModules ([
+      #   /etc/nix/inputs/nixpkgs/nixos/modules/system/boot/kernel.nix:          optionals config.boot.initrd.includeDefaultModules [
+      #   ````
+      initrd.includeDefaultModules = lib.mkForce false;
+      # Instead, we include only the modules we need for booting.
+      # NOTE: this is just the modules for booting, not the modules for the system!
+      # So you don't need to worry about missing modules for your hardware.
+      #
+      # To find out which modules you may need:
+      #   ```
+      #    $ grep -r 'availableKernelModules' ./nixpkgs/
+      #   ```
+      initrd.availableKernelModules = lib.mkForce [
+        # NVMe
+        "nvme"
+
+        # SD cards and internal eMMC drives.
+        "mmc_block"
+
+        # Support USB keyboards, in case the boot fails and we only have
+        # a USB keyboard, or for LUKS passphrase prompt.
+        "hid"
+
+        # For LUKS encrypted root partition.
+        # https://github.com/NixOS/nixpkgs/blob/nixos-23.11/nixos/modules/system/boot/luksroot.nix#L985
+        "dm_mod" # for LVM & LUKS
+        "dm_crypt" # for LUKS
+        "input_leds"
+      ];
+    };
+
+    hardware = {
+      # driver & firmware for Mali-G610 GPU
+      # it works on all rk2588/rk3588s based SBCs.
+      opengl.package =
+        (
+          (pkgs.mesa.override {
+            galliumDrivers = ["panfrost" "swrast"];
+            vulkanDrivers = ["swrast"];
+          })
+          .overrideAttrs (_: {
+            pname = "mesa-panfork";
+            version = "23.0.0-panfork";
+            src = pkgs.fetchFromGitLab {
+              owner = "panfork";
+              repo = "mesa";
+              rev = "120202c675749c5ef81ae4c8cdc30019b4de08f4"; # branch: csf
+              hash = "sha256-4eZHMiYS+sRDHNBtLZTA8ELZnLns7yT3USU5YQswxQ0=";
+            };
+          })
+        )
+        .drivers;
+
+      enableRedistributableFirmware = lib.mkForce true;
+      firmware = lib.mkIf config.hardware.mali.enableFirmware [
+        config.hardware.mali.firmwarePackage
+      ];
+    };
   };
 }

--- a/pkgs/mali-firmware/default.nix
+++ b/pkgs/mali-firmware/default.nix
@@ -4,11 +4,11 @@
 }:
 stdenv.mkDerivation {
   pname = "mali-g610-firmware";
-  version = "unstable-2022-11-21";
+  version = "g21p0-01eac0";
 
   src = fetchurl {
-    url = "https://github.com/JeffyCN/rockchip_mirrors/raw/309268f7a34ca0bba0ab94a0b09feb0191c77fb8/firmware/g610/mali_csffw.bin";
-    hash = "sha256-rZFRGnf6EQr0aiopytniJVJNnPqf41vc6WYG01TmB94=";
+    url = "https://github.com/JeffyCN/mirrors/raw/e08ced3e0235b25a7ba2a3aeefd0e2fcbd434b68/firmware/g610/mali_csffw.bin";
+    hash = "sha256-jnyCGlXKHDRcx59hJDYW3SX8NbgfCQlG8wKIbWdxLfU=";
   };
 
   buildCommand = ''


### PR DESCRIPTION
This PR enables users of this flake to use whatever G610 firmware they like (or disable it altogether). 

Also this PR updates libmali firmware to latest available in JeffyCN mirrors, thus fixing segfault in recent jellyfin-ffmpeg release and clinfo, both tested in jellyfin/jellyfin:10.9.1.20240513-003058 docker image (RepoDigest `jellyfin/jellyfin@sha256:54fa2eeac1dbb91aa1cadd8e741c0952792697ca996a8f1bd5e115d0550b6da8`) using Orange Pi 5.

This PR follows https://github.com/ryan4yin/nixos-rk3588/issues/32