### PR TITLE
Partially adding Orange Pi 5b (WIP)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,11 @@
           core = import ./modules/boards/orangepi5.nix;
           sd-image = ./modules/sd-image/orangepi5.nix;
         };
+        # Orange Pi 5b SBC
+        orangepi5b = {
+          core = import ./modules/boards/orangepi5b.nix;
+          sd-image = ./modules/sd-image/orangepi5b.nix;
+        };
         # Orange Pi 5 Plus SBC
         orangepi5plus = {
           core = import ./modules/boards/orangepi5plus.nix;
@@ -138,10 +143,12 @@
       packages = {
         # sdImage
         sdImage-opi5 = self.nixosConfigurations.orangepi5.config.system.build.sdImage;
+        sdImage-opi5b = self.nixosConfigurations.orangepi5b.config.system.build.sdImage;
         sdImage-opi5plus = self.nixosConfigurations.orangepi5plus.config.system.build.sdImage;
         sdImage-rock5a = self.nixosConfigurations.rock5a.config.system.build.sdImage;
 
         sdImage-opi5-cross = self.nixosConfigurations.orangepi5-cross.config.system.build.sdImage;
+        sdImage-opi5b-cross = self.nixosConfigurations.orangepi5-cross.config.system.build.sdImage;
         sdImage-opi5plus-cross = self.nixosConfigurations.orangepi5plus-cross.config.system.build.sdImage;
         sdImage-rock5a-cross = self.nixosConfigurations.rock5a-cross.config.system.build.sdImage;
 

--- a/modules/boards/orangepi5b.nix
+++ b/modules/boards/orangepi5b.nix
@@ -1,0 +1,48 @@
+# =========================================================================
+#      Orange Pi 5b Specific Configuration
+# =========================================================================
+{
+  pkgs,
+  rk3588,
+  ...
+}: let
+  pkgsKernel = rk3588.pkgsKernel;
+in {
+  imports = [
+    ./base.nix
+  ];
+
+  boot = {
+    kernelPackages = pkgsKernel.linuxPackagesFor (pkgsKernel.callPackage ../../pkgs/kernel/vendor.nix {});
+
+    # kernelParams copy from Armbian's /boot/armbianEnv.txt & /boot/boot.cmd
+    kernelParams = [
+      "rootwait"
+
+      "earlycon" # enable early console, so we can see the boot messages via serial port / HDMI
+      "consoleblank=0" # disable console blanking(screen saver)
+      "console=ttyS2,1500000" # serial port
+      "console=tty1" # HDMI
+
+      # docker optimizations
+      "cgroup_enable=cpuset"
+      "cgroup_memory=1"
+      "cgroup_enable=memory"
+      "swapaccount=1"
+    ];
+  };
+
+  # add some missing deviceTree in armbian/linux-rockchip:
+  # orange pi 5b's deviceTree in armbian/linux-rockchip:
+  #    https://github.com/armbian/linux-rockchip/blob/rk-5.10-rkr4/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5b.dts
+  hardware = {
+    deviceTree = {
+      name = "rockchip/rk3588s-orangepi-5b.dtb";
+      overlays = [];
+    };
+
+    firmware = [
+      (pkgs.callPackage ../../pkgs/orangepi-firmware {})
+    ];
+  };
+}

--- a/modules/sd-image/orangepi5b.nix
+++ b/modules/sd-image/orangepi5b.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  config,
+  rk3588,
+  ...
+}: let
+  rootPartitionUUID = "14e19a7b-0ae0-484d-9d54-43bd6fdc20c7";
+	uboot = pkgs.callPackage ../../pkgs/u-boot-opi5/prebuilt.nix {};
+in {
+  imports = [
+    "${rk3588.nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
+  ];
+
+  boot = {
+    kernelParams = [
+      "root=UUID=${rootPartitionUUID}"
+      "rootfstype=ext4"
+    ];
+
+    loader = {
+      grub.enable = lib.mkForce false;
+      generic-extlinux-compatible.enable = lib.mkForce true;
+    };
+  };
+
+  # add some missing deviceTree in armbian/linux-rockchip:
+  # orange pi 5b's deviceTree in armbian/linux-rockchip:
+  #    https://github.com/armbian/linux-rockchip/blob/rk-5.10-rkr4/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5b.dts
+  hardware = {
+    deviceTree = {
+      name = "rockchip/rk3588s-orangepi-5b.dtb";
+      overlays = [
+      ];
+    };
+
+    firmware = [];
+  };
+
+  sdImage = {
+    inherit rootPartitionUUID;
+    compressImage = true;
+
+    # install firmware into a separate partition: /boot/firmware
+    populateFirmwareCommands = ''
+      ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./firmware
+    '';
+    # Gap in front of the /boot/firmware partition, in mebibytes (1024×1024 bytes).
+    # Can be increased to make more space for boards requiring to dd u-boot SPL before actual partitions.
+    firmwarePartitionOffset = 32;
+    firmwarePartitionName = "BOOT";
+    firmwareSize = 200; # MiB
+
+    populateRootCommands = ''
+      mkdir -p ./files/boot
+    '';
+
+    # ???
+    # image location(sector): 0x40 - idbloader.img, pre-loader
+    # image location(sector): 0x4000 - u-boot.img, including u-boot and atf.
+    postBuildCommands = ''
+      # puts the Rockchip header and SPL image first at block 64 (0x40)
+      dd if=${uboot}/idbloader.img of=$img seek=64 conv=notrunc
+      # places the U-Boot image at block 16384 (0x4000)
+      dd if=${uboot}/u-boot.itb of=$img seek=16384 conv=notrunc
+    '';
+
+  };
+}

--- a/pkgs/u-boot-opi5/prebuilt.nix
+++ b/pkgs/u-boot-opi5/prebuilt.nix
@@ -1,0 +1,16 @@
+{stdenv}: let
+  # Prebuilt u-boot for rock-5a, built from armbian/build with command:
+  #   ./compile.sh build BOARD=rock-5a BRANCH=legacy BUILD_DESKTOP=no BUILD_MINIMAL=yes BUILD_ONLY=u-boot KERNEL_CONFIGURE=no RELEASE=bookworm
+  # And the unpack `output/debs/linux-u-boot-rock-5a-legacy_xxx.deb` to get the files below.
+  idbloader_img = ./linux-u-boot-legacy-orangepi-5/idbloader.img;
+  u_boot_itb = ./linux-u-boot-legacy-orangepi-5/u-boot.itb;
+in
+  stdenv.mkDerivation {
+    pname = "u-boot-prebuilt";
+    version = "unstable-2023-08-27";
+
+    buildCommand = ''
+      install -Dm444 ${idbloader_img} $out/idbloader.img
+      install -Dm444 ${u_boot_itb} $out/u-boot.itb
+    '';
+  }


### PR DESCRIPTION
Hello, 

This is an attempt to add the Orange Pi 5b (u-boot only currently).

### Differences:
The fundamental differences to the Orange Pi 5 are, that it has no SPI NOR flash (there is no `/dev/mtdblock0` device) and it's `deviceTree.name` is `rockchip/rk3588s-orangepi-5b.dtb` and also that it uses internal eMMC by default. Instead of flashing the u-boot into the SPI NOR flash, it should bundle inside sdImage just as Rock5a (I think).

### Whats missing?
Unfortunately because I am not sure, I removed `# enable pcie2x1l2 (NVMe), disable sata0` and `# enable i2c1 overlays` from OPI5 nix file. I think i2c1 should stay inside?

Also this needs a prebuilt u-boot for the Orange Pi 5 (`idbloader.img & u-boot.itb`) inside the `pkgs/u-boot-opi5/linux-u-boot-legacy-orangepi-5/` folder. I named folder opi5 because this prebuilt u-boot should work for both versions? Not sure.

### What else?
So this pull request is not ready.

I hope somebody can help, because I don't know very much about this. Maybe this PR just works if we provide prebuilt u-boot?