### PR TITLE
feat: Add Orange Pi 5b support with u-boot (WIP)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,11 @@
           core = import ./modules/boards/orangepi5.nix;
           sd-image = ./modules/sd-image/orangepi5.nix;
         };
+        # Orange Pi 5b SBC
+        orangepi5b = {
+          core = import ./modules/boards/orangepi5b.nix;
+          sd-image = ./modules/sd-image/orangepi5b.nix;
+        };
         # Orange Pi 5 Plus SBC
         orangepi5plus = {
           core = import ./modules/boards/orangepi5plus.nix;
@@ -138,10 +143,12 @@
       packages = {
         # sdImage
         sdImage-opi5 = self.nixosConfigurations.orangepi5.config.system.build.sdImage;
+        sdImage-opi5b = self.nixosConfigurations.orangepi5b.config.system.build.sdImage;
         sdImage-opi5plus = self.nixosConfigurations.orangepi5plus.config.system.build.sdImage;
         sdImage-rock5a = self.nixosConfigurations.rock5a.config.system.build.sdImage;
 
         sdImage-opi5-cross = self.nixosConfigurations.orangepi5-cross.config.system.build.sdImage;
+        sdImage-opi5b-cross = self.nixosConfigurations.orangepi5b-cross.config.system.build.sdImage;
         sdImage-opi5plus-cross = self.nixosConfigurations.orangepi5plus-cross.config.system.build.sdImage;
         sdImage-rock5a-cross = self.nixosConfigurations.rock5a-cross.config.system.build.sdImage;
 

--- a/modules/boards/orangepi5b.nix
+++ b/modules/boards/orangepi5b.nix
@@ -1,0 +1,48 @@
+# =========================================================================
+#      Orange Pi 5b Specific Configuration
+# =========================================================================
+{
+  pkgs,
+  rk3588,
+  ...
+}: let
+  pkgsKernel = rk3588.pkgsKernel;
+in {
+  imports = [
+    ./base.nix
+  ];
+
+  boot = {
+    kernelPackages = pkgsKernel.linuxPackagesFor (pkgsKernel.callPackage ../../pkgs/kernel/vendor.nix {});
+
+    # kernelParams copy from Armbian's /boot/armbianEnv.txt & /boot/boot.cmd
+    kernelParams = [
+      "rootwait"
+
+      "earlycon" # enable early console, so we can see the boot messages via serial port / HDMI
+      "consoleblank=0" # disable console blanking(screen saver)
+      "console=ttyS2,1500000" # serial port
+      "console=tty1" # HDMI
+
+      # docker optimizations
+      "cgroup_enable=cpuset"
+      "cgroup_memory=1"
+      "cgroup_enable=memory"
+      "swapaccount=1"
+    ];
+  };
+
+  # add some missing deviceTree in armbian/linux-rockchip:
+  # orange pi 5b's deviceTree in armbian/linux-rockchip:
+  #    https://github.com/armbian/linux-rockchip/blob/rk-5.10-rkr4/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5b.dts
+  hardware = {
+    deviceTree = {
+      name = "rockchip/rk3588s-orangepi-5b.dtb";
+      overlays = [];
+    };
+
+    firmware = [
+      (pkgs.callPackage ../../pkgs/orangepi-firmware {})
+    ];
+  };
+}

--- a/modules/sd-image/orangepi5b.nix
+++ b/modules/sd-image/orangepi5b.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  config,
+  pkgs,
+  rk3588,
+  ...
+}: let
+  rootPartitionUUID = "14e19a7b-0ae0-484d-9d54-43bd6fdc20c7";
+  uboot = pkgs.callPackage ../../pkgs/u-boot-opi5b/prebuilt.nix {};
+in {
+  imports = [
+    "${rk3588.nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
+  ];
+
+  boot = {
+    kernelParams = [
+      "root=UUID=${rootPartitionUUID}"
+      "rootfstype=ext4"
+    ];
+
+    loader = {
+      grub.enable = lib.mkForce false;
+      generic-extlinux-compatible.enable = lib.mkForce true;
+    };
+  };
+
+  # add some missing deviceTree in armbian/linux-rockchip:
+  # orange pi 5b's deviceTree in armbian/linux-rockchip:
+  #    https://github.com/armbian/linux-rockchip/blob/rk-5.10-rkr4/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5b.dts
+  hardware = {
+    deviceTree = {
+      name = "rockchip/rk3588s-orangepi-5b.dtb";
+      overlays = [
+      ];
+    };
+
+    firmware = [];
+  };
+
+  sdImage = {
+    inherit rootPartitionUUID;
+    compressImage = true;
+
+    # install firmware into a separate partition: /boot/firmware
+    populateFirmwareCommands = ''
+      ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./firmware
+    '';
+    # Gap in front of the /boot/firmware partition, in mebibytes (1024×1024 bytes).
+    # Can be increased to make more space for boards requiring to dd u-boot SPL before actual partitions.
+    firmwarePartitionOffset = 32;
+    firmwarePartitionName = "BOOT";
+    firmwareSize = 200; # MiB
+
+    populateRootCommands = ''
+      mkdir -p ./files/boot
+    '';
+
+    # ???
+    # image location(sector): 0x40 - u-boot.bin.
+    postBuildCommands = ''
+      # places the U-Boot image at block first at block 64 (0x40)
+      dd if=${uboot}/u-boot.bin of=$img seek=64 conv=notrunc
+    '';
+
+  };
+}

--- a/pkgs/u-boot-opi5b/prebuilt.nix
+++ b/pkgs/u-boot-opi5b/prebuilt.nix
@@ -1,0 +1,13 @@
+{stdenv}: let
+  # Prebuilt u-boot for orangepi-5b with smmc-enable.patch provided from:
+  #   https://github.com/fb87/nixos-orangepi-5x
+  u_boot_bin = ./linux-u-boot-legacy-orangepi-5b/u-boot.bin;
+in
+  stdenv.mkDerivation {
+    pname = "u-boot-prebuilt";
+    version = "unstable-2023-07-02";
+
+    buildCommand = ''
+      install -Dm444 ${u_boot_bin} $out/u-boot.bin
+    '';
+  }


### PR DESCRIPTION
Hello,

This is an attempt to add the Orange Pi 5b (u-boot only currently).

### Differences

The fundamental differences from the Orange Pi 5b to the Orange Pi 5 are:

- that it has no SPI NOR flash (there is no `/dev/mtdblock0` device) -> Instead of flashing the u-boot into the SPI NOR flash, it should bundle inside sdImage just as Rock5a (I think).

- it's deviceTree.name is `rockchip/rk3588s-orangepi-5b.dtb` 

- it uses internal eMMC by default. 

- other (not important for image to work like wifi)

### Whats missing?

- Unfortunately because I am not sure, I removed **# enable pcie2x1l2 (NVMe)**, disable sata0 and # **enable i2c1 overlays** from the OPI5 nix file that i copied. **I think i2c1 should stay inside?**

- Also this needs a prebuilt u-boot for the Orange Pi 5 (`idbloader.img & u-boot.itb`) inside the `pkgs/u-boot-opi5/linux-u-boot-legacy-orangepi-5/` folder. **I named folder opi5 because this prebuilt u-boot should theoretically work for both versions? Not sure.**

### What else?

So this pull request is not ready.

I hope somebody can help, because I don't know very much about this. Maybe this PR just works if we just provide the missing prebuilt u-boot?