### PR TITLE
create a nixos-generators custom raw-efi format and use it to copy DTB files into /boot/dtb/base

### DIFF
--- a/UEFI.md
+++ b/UEFI.md
@@ -67,16 +67,7 @@ cat result | sudo dd status=progress bs=8M of=/dev/sdX
 
 # Due to https://github.com/ryan4yin/nixos-rk3588/issues/22
 # We have to add our dtbs into edk2-rk3588's overlays folder `/boot/dtb/base`
-mkdir boot root
-mkdir -p /boot/dtb/base
-mount /dev/sdX1 boot
-mount /dev/sdX2 root
-# Get the hash of the kernel image
-ls boot/kernels/ | grep Image  # => 9h87sqy9ix9qsvlyqcqsmjbzfs1ymgqx-k-Image
-# Copy the dtb file to the overlays folder, the name should be the same as the hash of the kernel image
- cp root/nix/store/9h87sqy9ix9qsvlyqcqsmjbzfs1ymgqx-k/dtbs/rockchip/* /boot/dtb/base/
-umount boot root
-sudo sync
+# This is now done automatically as part of the rk3588-raw-efi format. See: modules/rk3588-raw-efi.nix
 
 # ====================================
 # For Rock 5A(Not Work Yet!!!)

--- a/modules/rk3588-raw-efi.nix
+++ b/modules/rk3588-raw-efi.nix
@@ -1,0 +1,26 @@
+{
+  config,
+  lib,
+  options,
+  pkgs,
+  modulesPath,
+  nixos-generators,
+  ...
+}: let
+  # Import raw-efi from nixos-generators
+  raw-efi = nixos-generators.nixosModules.raw-efi;
+
+  extraInstallCommands = ''
+    mkdir -p /boot/dtb/base
+    cp -r ${config.boot.kernelPackages.kernel}/dtbs/rockchip/* /boot/dtb/base/
+    sync
+  '';
+in {
+  # Reuse and extend the raw-efi format
+  imports = [raw-efi];
+
+  boot.loader = {
+    systemd-boot.extraInstallCommands = extraInstallCommands;
+    grub.extraInstallCommands = extraInstallCommands;
+  };
+}


### PR DESCRIPTION
create a nixos-generators custom format and use it to copy DTB files into /boot/dtb/base during the boot loader install process of building the image.


I am not 100% sure if this line is correct for a cross build, everything works when building the image natively though.
```
nixpkgs.hostPlatform = aarch64System
```

It looks like it is possible to use the custom format to also set the efi boot variables so it wont be necessary to open up the UEFI boot menu and set them manually.