### PR TITLE
Remove mesa panfork override

### DIFF
--- a/modules/boards/base.nix
+++ b/modules/boards/base.nix
@@ -75,27 +75,6 @@
     };
 
     hardware = {
-      # driver & firmware for Mali-G610 GPU
-      # it works on all rk2588/rk3588s based SBCs.
-      opengl.package =
-        (
-          (pkgs.mesa.override {
-            galliumDrivers = ["panfrost" "swrast"];
-            vulkanDrivers = ["swrast"];
-          })
-          .overrideAttrs (_: {
-            pname = "mesa-panfork";
-            version = "23.0.0-panfork";
-            src = pkgs.fetchFromGitLab {
-              owner = "panfork";
-              repo = "mesa";
-              rev = "120202c675749c5ef81ae4c8cdc30019b4de08f4"; # branch: csf
-              hash = "sha256-4eZHMiYS+sRDHNBtLZTA8ELZnLns7yT3USU5YQswxQ0=";
-            };
-          })
-        )
-        .drivers;
-
       enableRedistributableFirmware = lib.mkForce true;
       firmware = lib.mkIf config.hardware.mali.enableFirmware [
         config.hardware.mali.firmwarePackage


### PR DESCRIPTION
Is not online anymore. It says use upstream, otherwise I get compilation error because 404 not found
https://gitlab.com/panfork/mesa

does it still need this? and other stuff  there?

```
          ...
          (pkgs.mesa.override {
            galliumDrivers = ["panfrost" "swrast"];
            vulkanDrivers = ["swrast"];
          })
         ...
```