### PR TITLE
Add u-boot compile, precompiled u-boot for opi5b, update some packages

### DIFF
--- a/modules/sd-image/orangepi5b.nix
+++ b/modules/sd-image/orangepi5b.nix
@@ -6,7 +6,10 @@
   ...
 }: let
   rootPartitionUUID = "14e19a7b-0ae0-484d-9d54-43bd6fdc20c7";
+  # use prebuilt u-boot
   uboot = pkgs.callPackage ../../pkgs/u-boot-opi5b/prebuilt.nix {};
+  # or build u-boot from source (comment/uncomment)
+  # uboot = pkgs.callPackage ../../pkgs/u-boot-opi5b/build-from-source.nix {};
 in {
   imports = [
     "${rk3588.nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"

--- a/pkgs/orangepi-firmware/default.nix
+++ b/pkgs/orangepi-firmware/default.nix
@@ -8,8 +8,8 @@
     src = fetchFromGitHub {
         owner = "orangepi-xunlong";
         repo = "firmware";
-        rev = "76ead17a1770459560042a9a7c43fe615bbce5e7";
-        hash = "sha256-mltaup92LTGbuCXeGTMdoFloX3vZRbaUFVbh6lwveFs=";
+        rev = "75ea6fc5f3c454861b39b33823cb6876f3eca598";
+        hash = "sha256-X+n0voO3HRtPPAQsajGPIN9LOfDKBxF+8l9wFwGAFSQ=";
     };
 
     installPhase = ''

--- a/pkgs/rkbin-rk3588/default.nix
+++ b/pkgs/rkbin-rk3588/default.nix
@@ -10,8 +10,8 @@ stdenvNoCC.mkDerivation {
   src = fetchFromGitHub {
     owner = "armbian";
     repo = "rkbin";
-    rev = "ff684f607af661ac0ef5ce59f0533adb2beb6e12";
-    sha256 = "sha256-sOhdlvdQrH7eykPV2y2r7/NqNcxdgtnBshQAka6ZXD0=";
+    rev = "12657ed7c65f16f89e6bd5ea82ca670d3324fc70";
+    sha256 = "sha256-Lyo4LHg8HfeJTQ0Y29d0ITdF1JDOFOmgK2JxvBlKL1E=";
   };
 
   installPhase = ''

--- a/pkgs/u-boot-opi5b/build-from-source.nix
+++ b/pkgs/u-boot-opi5b/build-from-source.nix
@@ -30,7 +30,7 @@ in
       flex
       openssl
       bc
-    ] ++ [ rkbin ];
+    ] ++ [ rkbin-rk3588 ];
     
     configurePhase = ''
       make ARCH=arm evb-rk3588_defconfig

--- a/pkgs/u-boot-opi5b/build-from-source.nix
+++ b/pkgs/u-boot-opi5b/build-from-source.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  fetchFromGitHub,
+  pkgs,
+  stdenv,
+}: let
+  rkbin-rk3588 = (pkgs.callPackage ../rkbin-rk3588 {});
+in 
+  stdenv.mkDerivation {
+    pname = "u-boot";
+    version = "v2023.07.02";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "u-boot";
+      repo = "u-boot";
+      rev = "83cdab8b2c6ea0fc0860f8444d083353b47f1d5c"; # "v2023.07.02" branch
+      sha256 = "sha256-HPBjm/rIkfTCyAKCFvCqoK7oNN9e9rV9l32qLmI/qz4=";
+    };
+
+    nativeBuildInputs = with pkgs; [
+      (python3.withPackages (p: with p; [
+        setuptools
+        pyelftools
+      ]))
+
+      swig
+      ncurses
+      gnumake
+      bison
+      flex
+      openssl
+      bc
+    ] ++ [ rkbin ];
+    
+    configurePhase = ''
+      make ARCH=arm evb-rk3588_defconfig
+    '';
+
+    buildPhase = ''
+      patchShebangs tools scripts
+      make -j$(nproc) \
+        ROCKCHIP_TPL=${rkbin-rk3588}/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.15.bin \
+        BL31=${rkbin-rk3588}/rk3588_bl31_v1.45.elf
+    '';
+
+    installPhase = ''
+      mkdir $out
+      cp u-boot-rockchip.bin $out/u-boot.bin
+    '';
+  }
+


### PR DESCRIPTION
Hello,

this PR adds an optional u-boot compile for the opi5b and also updates the precompiled one (to uses newest version of rkbin binaries, old one used older ones from default vendor) of these:
```
ROCKCHIP_TPL=${rkbin-rk3588}/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.15.bin \
BL31=${rkbin-rk3588}/rk3588_bl31_v1.45.elf
```
(before it used tpl v1.05 or so and bl31 v1.40 so little newer than u-boot which i copied from f87's repo before)

One can **toggle off/on** by **comment/uncomment** u-boot version in beginning of `modules/sd-image/orangepi5b.nix` file, it's disabled by default, because nix gives error on cross-compile (its nix issue). native compile works fine so its opt in and disabled by default.

_Also some minor update to use latest commits of rkbin-rk3588 & orangepi-firmware (I think there are no relevant changes for this board because its just a few commits like 2 or 3 newer. But to ensure everything is up-to-date)._

**BTW:** this is plain u-boot without any patches, so if opi5 and opi5-plus etc use also the mentioned ROCKCHIP_TPL and BL31 from above, this u-boot also works for them. So one would not have to install armbian first then flash u-boot to spi, they could just flash this u-boot to SPI directly (i think). It would be better to add nix build option to compile u-boot only for these SPI devices, but I am very new to nix flake and is very confusing.

Thanks a lot