### PR TITLE
Update the hash of hbiyik-panthor.patch

### DIFF
--- a/pkgs/kernel/vendor.nix
+++ b/pkgs/kernel/vendor.nix
@@ -40,7 +40,7 @@ in
     # reorders the patches, and the order matters since they're generated from commits.
     patch = fetchurl {
       url = "https://github.com/hbiyik/linux/compare/${panthor-base}...${panthor-head}.patch";
-      hash = "sha256-/5SvlGsgHbn1i68+GASOeNZmxoZiIt280L6iUFz3MFU=";
+      hash = "sha256-nSfmgem0CElUHL1wXSL+9aVixeaRjcxMyey4YaNdHfc=";
     };
     extraConfig = { };
   }];


### PR DESCRIPTION
The hash of the data received from Github has changed for some reason. I don't know why (could be something with spaces, encoding that they changed), but this commit fixes it.

Fixes #63